### PR TITLE
Fix for bnc#843438.

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -104,6 +104,7 @@ struct {
   { di_390net_escon,	 "ESCON"         },
   { di_390net_iucv,	 "Inter-User Communication Vehicle (IUCV)"          },
   { di_390net_hsi,	 "Hipersockets"	          },
+  { di_390net_virtio,	 "VirtIO Ethernet CCW Device"},
   { di_390net_sep,	 "#--------------------" },
   
   { di_ctc_compat,	 "Compatibility mode (default)"      },

--- a/dialog.h
+++ b/dialog.h
@@ -85,6 +85,7 @@ typedef enum {
   di_390net_escon,
   di_390net_iucv,
   di_390net_hsi,
+  di_390net_virtio,
   di_390net_eth,
   di_390net_qdio,
   di_390net_lcs,

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -44,6 +44,7 @@
 #include "scsi_rename.h"
 #include "checkmedia.h"
 #include "url.h"
+#include <sys/utsname.h>
 
 #if defined(__alpha__) || defined(__ia64__)
 #define SIGNAL_ARGS	int signum, int x, struct sigcontext *scp
@@ -658,6 +659,7 @@ void lxrc_init()
 {
   int i, j;
   char buf[256];
+  struct utsname utsinfo;
 
   siginterrupt(SIGALRM, 1);
   signal(SIGHUP, SIG_IGN);
@@ -711,6 +713,11 @@ void lxrc_init()
     else {
       config.hwp.hypervisor = "Unknown";
     }
+  }
+  else {
+    uname(&utsinfo);
+    if(!strncmp(utsinfo.machine, "s390x", sizeof "s390x" - 1 )) config.hwp.hypervisor="KVM";
+    else config.hwp.hypervisor="Reallyunknown";
   }
   #endif
 

--- a/net.c
+++ b/net.c
@@ -1353,7 +1353,7 @@ int net_choose_device()
      IUCV is available for use unless the driver is already loaded. So,
      if we're running on z/VM we always load it, no matter what.       */
   #if defined(__s390__) || defined(__s390x__)
-  if(strncmp(config.hwp.hypervisor,"z/VM",4)==0) {
+  if(!strncmp(config.hwp.hypervisor, "z/VM", sizeof "z/VM" - 1 )) {
      dia_info(&win, "We are running on z/VM", MSGTYPE_INFO);
      dia_info(&win, "Loading the IUCV network driver", MSGTYPE_INFO);
      mod_modprobe("netiucv","");
@@ -2440,7 +2440,8 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
     break;
   default:
     return -1;
-  } else {	/* no hd_t entry -> ask */
+  }
+  else {	/* no hd_t entry -> ask */
     dia_item_t di;
     dia_item_t items[] = {
       di_390net_osa,
@@ -2451,14 +2452,18 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       di_390net_iucv,
       di_none
     };
-  
+    if(!strncmp(config.hwp.hypervisor, "KVM", sizeof "KVM" - 1)) {
+      items[0] = di_390net_virtio;
+      items[1] = di_none;
+    }
+
     IFNOTAUTO(config.hwp.type) {
       di = dia_menu2("Please select the type of your network device.", 60, 0, items, config.hwp.type?:di_390net_iucv);
       config.hwp.type = di;
-    } else di = config.hwp.type;
+    }
+    else di = config.hwp.type;
   }
-       
-  
+
   /* hwcfg parms common to all devices */
   config.hwp.startmode="auto";
   config.hwp.module_options="";


### PR DESCRIPTION
  Add KVM detection on s390x.
  If running under KVM on s390x, only offer a virtio network device.
