### PR TITLE
- s390: choose thermonuclear option to deal with whitespace issues

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -1661,7 +1661,20 @@ int dia_show_lines2(char *head, slist_t *sl0, int width)
   return j;
 }
 
+
+#if defined(__s390__) || defined(__s390x__)
+/* broken HMC terminal workaround: always chop leading and trailing whitespace */
+int dia_input2_chopspace(char* txt, char** input, int fieldlen, int pw_mode);
+
 int dia_input2(char *txt, char **input, int fieldlen, int pw_mode)
+{
+  return dia_input2_chopspace(txt, input, fieldlen, pw_mode);
+}
+
+static int __dia_input2(char *txt, char **input, int fieldlen, int pw_mode)
+#else
+int dia_input2(char *txt, char **input, int fieldlen, int pw_mode)
+#endif
 {
   char buf[1024];
   int i;
@@ -1695,7 +1708,11 @@ int dia_input2_chopspace(char* txt, char** input, int fieldlen, int pw_mode)
   if (*input)
     deflt = strdup(*input);
 
+#if defined(__s390__) || defined(__s390x__)
+  retval = __dia_input2(txt, input, fieldlen, pw_mode);
+#else
   retval = dia_input2(txt, input, fieldlen, pw_mode);
+#endif
   oinput = *input;
 
   /* null pointer or empty string */

--- a/file.c
+++ b/file.c
@@ -1177,7 +1177,7 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         if(*f->value) str_copy(&config.hwp.userid, f->value);
         break;
       case key_portname:
-        if(*f->value) str_copy(&config.hwp.portname, f->value);
+        str_copy(&config.hwp.portname, f->value);
         break;
       case key_readchan:
         if(*f->value) str_copy(&config.hwp.readchan, f->value);
@@ -1199,9 +1199,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         break;
       case key_portno:
         if(f->is.numeric) config.hwp.portno = f->nvalue + 1;
+        else config.hwp.portno = 1;
         break;
       case key_osahwaddr:
-        if(*f->value) str_copy(&config.hwp.osahwaddr, f->value);
+        str_copy(&config.hwp.osahwaddr, f->value);
         break;
 #endif      
 


### PR DESCRIPTION
  once and for all (bnc#706605)
- s390: allow empty parameters for portname, portno and
  osahwaddr (bnc#720765)
