### PR TITLE
moved edd.ko loading into udev start script (bnc #871617)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -906,11 +906,6 @@ void lxrc_init()
     mount("devpts", "/dev/pts", "devpts", 0, 0);
   }
 
-  // we might need edd for udev
-  if(util_check_exist("/modules/edd.ko")) {
-    system("/sbin/insmod /modules/edd.ko 2>/dev/null");
-  }
-
   util_set_stderr(config.stderr_name);
 
   time_t t = time(NULL);


### PR DESCRIPTION
We need to load more modules before starting udevd. Doing this in udev_setup
now. See related change in installation-images.
