### PR TITLE
gpg 2.1.1 became stricter with the usage of --verify:

### DIFF
--- a/url.c
+++ b/url.c
@@ -1519,8 +1519,8 @@ int url_read_file(url_t *url, char *dir, char *src, char *dst, char *label, unsi
   }
   strprintf(&dst_sig, "%s.asc", dst);
   strprintf(&buf,
-    "gpg --homedir /root/.gnupg --batch --no-default-keyring --keyring /installkey.gpg --ignore-valid-from --ignore-time-conflict --verify %s >/dev/null%s",
-    dst_sig, config.debug < 2 ? " 2>&1" : ""
+    "gpg --homedir /root/.gnupg --batch --no-default-keyring --keyring /installkey.gpg --ignore-valid-from --ignore-time-conflict --verify %s %s >/dev/null%s",
+    dst_sig, dst, config.debug < 2 ? " 2>&1" : ""
   );
 
   err = url_read_file_nosig(url, dir, src_sig, dst_sig, NULL, flags);


### PR DESCRIPTION
the man page states:
"If you are going to verify detached signatures, make sure that the
 program knows about it; either give both filenames on the command
 line or  use  '-' to specify STDIN.".

To comply to this, we also  pass the file to be verified into the command line.