### PR TITLE
Backported the following commits from SLE12 to fix bug#909528

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -109,6 +109,7 @@ struct {
   { di_390net_escon,	 TXT_390NET_ESCON         },
   { di_390net_iucv,	 TXT_390NET_IUCV          },
   { di_390net_hsi,	 TXT_390NET_HSI	          },
+  { di_390net_virtio,	 TXT_390NET_VIRTIO        },
   { di_390net_sep,	 0, "#--------------------" },
   
   { di_ctc_compat,	 TXT_CTC_PROT_COMPAT      },

--- a/dialog.h
+++ b/dialog.h
@@ -88,6 +88,7 @@ typedef enum {
   di_390net_escon,
   di_390net_iucv,
   di_390net_hsi,
+  di_390net_virtio,
   di_390net_eth,
   di_390net_tr,
   di_390net_qdio,

--- a/global.h
+++ b/global.h
@@ -614,6 +614,7 @@ typedef struct {
     int layer2;
     int portno;
     char* osahwaddr;
+    char* hypervisor;
   } hwp;
   
 #endif

--- a/po/af.po
+++ b/po/af.po
@@ -906,6 +906,10 @@ msgstr "Intergebruiker-kommunikasietuig (IUCV, Inter-User Communication Vehicle)
 msgid "Hipersockets"
 msgstr "Hipersokke"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Toesteladres vir leeskanaal"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1072,6 +1072,10 @@ msgstr "Това не е валиден CCW адрес."
 msgid "Hipersocket"
 msgstr "Hipersocket"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. power-off message
 #. TXT_HALT
 msgid "Do you want to halt the system now?"

--- a/po/ca.po
+++ b/po/ca.po
@@ -909,6 +909,10 @@ msgstr "IUCV (Inter-User Communication Vehicle)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Adreça del dispositiu per al canal de lectura"

--- a/po/cs.po
+++ b/po/cs.po
@@ -911,6 +911,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Adresa zařízení pro čtecí kanál"

--- a/po/da.po
+++ b/po/da.po
@@ -911,6 +911,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Enhedsadressen for læsekanalen"

--- a/po/de.po
+++ b/po/de.po
@@ -910,6 +910,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Geräteadresse für Lesekanal"

--- a/po/el.po
+++ b/po/el.po
@@ -915,6 +915,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Διεύθυνση συσκευής για το κανάλι ανάγνωσης"

--- a/po/es.po
+++ b/po/es.po
@@ -912,6 +912,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Dirección del dispositivo para el canal de lectura"

--- a/po/fi.po
+++ b/po/fi.po
@@ -910,6 +910,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Laiteosoite lukukanavalle"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1080,6 +1080,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Adresse du périphérique pour le canal de lecture"

--- a/po/hu.po
+++ b/po/hu.po
@@ -915,6 +915,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Eszköz címe a csatornaolvasáshoz"

--- a/po/it.po
+++ b/po/it.po
@@ -905,6 +905,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Indirizzo di dispositivo per canale di lettura"

--- a/po/ja.po
+++ b/po/ja.po
@@ -906,6 +906,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "読み取りチャネルに対するデバイスアドレス"

--- a/po/linuxrc.pot
+++ b/po/linuxrc.pot
@@ -860,6 +860,10 @@ msgstr ""
 msgid "Hipersockets"
 msgstr ""
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr ""
@@ -1191,4 +1195,3 @@ msgstr ""
 #. TXT_HWADDR
 msgid "MAC address"
 msgstr ""
-

--- a/po/nb.po
+++ b/po/nb.po
@@ -913,6 +913,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Enhetsadresse for lesekanal"

--- a/po/nl.po
+++ b/po/nl.po
@@ -908,6 +908,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Apparaat adres voor leeskanaal"

--- a/po/pl.po
+++ b/po/pl.po
@@ -906,6 +906,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Adres urządzenia dla kanału odczytu"

--- a/po/pt.po
+++ b/po/pt.po
@@ -911,6 +911,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Endereço do dispositivo para o canal de leitura"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -906,6 +906,10 @@ msgstr "IUCV (Inter User Communication Vehicle - Veículo de Comunicação entre
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Endereço de dispositivo para canal de leitura"

--- a/po/ru.po
+++ b/po/ru.po
@@ -902,6 +902,10 @@ msgstr "Средство связи между пользователями (IUC
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Адрес устройства для чтения канала"

--- a/po/sk.po
+++ b/po/sk.po
@@ -913,6 +913,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Adresa zariadenia pre kanál na čítanie"

--- a/po/sl.po
+++ b/po/sl.po
@@ -911,6 +911,10 @@ msgstr ""
 msgid "Hipersockets"
 msgstr ""
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Naslov naprave za bralni kanal"

--- a/po/sv.po
+++ b/po/sv.po
@@ -909,6 +909,10 @@ msgstr "IUCV (Inter-User Communication Vehicle)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Enhetsadress för läskanal"

--- a/po/uk.po
+++ b/po/uk.po
@@ -911,6 +911,10 @@ msgstr "Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Адреса пристрою для каналу читання"

--- a/po/xh.po
+++ b/po/xh.po
@@ -903,6 +903,10 @@ msgstr "Isithuthi Sonxibelelwano Phakathi Kwabasebenzisi (IUCV)"
 msgid "Hipersockets"
 msgstr "Iisokethi ze-Hiper"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Idilesi yesixhobo sokufunda umjelo"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -906,6 +906,10 @@ msgstr "用户间通讯载体 (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "读取通道的设备地址"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -906,6 +906,10 @@ msgstr "內部使用者通訊處 (IUCV)"
 msgid "Hipersockets"
 msgstr "Hipersockets"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "讀取通道的設備位址"

--- a/po/zu.po
+++ b/po/zu.po
@@ -906,6 +906,10 @@ msgstr "I-Inter-User Communication Vehicle (IUCV)"
 msgid "Hipersockets"
 msgstr "Ama-hipersocket"
 
+#. TXT_390NET_VIRTIO
+msgid "VirtIO Ethernet CCW Device"
+msgstr ""
+
 #. TXT_CTC_CHANNEL_READ
 msgid "Device address for read channel"
 msgstr "Ikheli ledivayisi lesiteshi sokufunda"


### PR DESCRIPTION
This is a backport of a fix made for SLES12 to prompt for a virtio network device when running as a KVM guest.