### PR TITLE
Bnc 901598 2

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -530,6 +530,10 @@ int test_and_add_dud(url_t *url)
   if(!is_dud && (url->is.file || !url->is.mountable)) {
     is_dud = 1;
 
+    // log as driver update
+    config.update.count++;
+    slist_append_str(&config.update.name_list, url->path);
+
     s = url_print(url, 1);
 
     printf("%s: adding to %s system\n", s, config.rescue ? "rescue" : "installation");

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -872,7 +872,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2014 SUSE Linux Products GmbH <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2015 SUSE Linux GmbH <<<\n",
       config.product
     );
     if (config.linemode)


### PR DESCRIPTION
As a result of bnc #901598 we would now get a warning dialog when using a plain rpm in the 'dud' option. This is fixed in two steps: (1) count rpms a driver updates internally and (2) verify the rpm signature (duds must be signed unless you run in 'insecure' mode).