### PR TITLE
Do not display an error message after aborting YaST (bsc#614829)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 changelog
 Changelog
 VERSION
+*.o
+.depend
+linuxrc
+mkpsfu/mkpsfu
+version.h

--- a/install.c
+++ b/install.c
@@ -1292,7 +1292,7 @@ int inst_execute_yast()
 
   if(config.manual) util_disp_init();
 
-  if(err && config.win) {
+  if(err && !config.aborted && config.win) {
     dia_message("An error occurred during the installation.", MSGTYPE_ERROR);
   }
 


### PR DESCRIPTION
Display the main menu directly.

Tested with `sudo ./mksusecd --micro --initrd /tmp/initrd --create /tmp/test.iso openSUSE-13.2-DVD-x86_64.iso`, after aborting the installation the error message is skipped and the main menu is displayed.