### PR TITLE
- avoid any interactive dialogs when checking the digest of files during

### DIFF
--- a/global.h
+++ b/global.h
@@ -374,6 +374,7 @@ typedef struct {
   char *zenconfig;		/* zenworks config file */
   unsigned ntfs_3g:1;		/* use ntfs-3g */
   unsigned secure:1;		/* secure mode (check digest of all downloaded files) */
+  unsigned secure_always_fail:1;	/* in secure mode: never ask the user but always fail directly */
   unsigned sslcerts:1;		/* whether to check ssl certificates */
   unsigned sig_failed:2;	/* signature check failed (1: not signed, 2: wrong signature) */
   unsigned kexec:1;		/* kexec to kernel & initrd from repo */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1476,6 +1476,8 @@ void lxrc_usr1(int signum)
         if(!config.debug) config.debug = 1;
 
         config.keepinstsysconfig = 1;
+        config.linemode = 1;
+        config.secure_always_fail = 1;
 
         if(task == 'a' && sl) {
           fprintf(stderr, "instsys extend: add %s\n%s: already added\n", ext, ext);


### PR DESCRIPTION
  an 'extend' command (bsc #936068)