### PR TITLE
s390x: in install type dialog, make vnc & ssh mutually exclusive (bsc…

### DIFF
--- a/install.c
+++ b/install.c
@@ -304,11 +304,13 @@ int inst_choose_display_cb(dia_item_t di)
 
     case di_display_vnc:
       config.vnc=1;
+      config.ssh=0;
       net_ask_password();
       break;
 
     case di_display_ssh:
       config.usessh=1;
+      config.vnc=0;
       net_ask_password();
       break;
 

--- a/install.c
+++ b/install.c
@@ -304,7 +304,7 @@ int inst_choose_display_cb(dia_item_t di)
 
     case di_display_vnc:
       config.vnc=1;
-      config.ssh=0;
+      config.usessh=0;
       net_ask_password();
       break;
 


### PR DESCRIPTION
… #943744)

The dialog presents the various choices as alternatives; so change the code to make this true.

This is only for s390x and doesn't affect setting vnc/ssh via command line or the linuxrc settings dialog.