### PR TITLE
s390x: keep ssh active when selecting vnc (bsc #943744)

### DIFF
--- a/install.c
+++ b/install.c
@@ -304,7 +304,6 @@ int inst_choose_display_cb(dia_item_t di)
 
     case di_display_vnc:
       config.vnc=1;
-      config.usessh=0;
       net_ask_password();
       break;
 


### PR DESCRIPTION
revert a bit of the last change