### PR TITLE
get rid of 'no job control' bash messages (bsc #945607)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -1520,7 +1520,10 @@ void dia_handle_ctrlc (void)
           fflush(stdout);
         }
 
-        system("exec bash -l 2>&1");
+        char *cmd = NULL;
+        strprintf(&cmd, "exec %s 2>&1", config.debugshell ?: "/bin/sh");
+        system(cmd);
+        free(cmd);
 
         kbd_init(0);
         if(config.win) {

--- a/file.c
+++ b/file.c
@@ -307,6 +307,7 @@ static struct {
   { key_vlanid,         "VLanID",         kf_cfg + kf_cmd                },
   { key_systemboot,     "SystemBoot",     kf_cfg + kf_cmd                },
   { key_sethostname,    "SetHostname",    kf_cfg + kf_cmd_early          },
+  { key_debugshell,     "DebugShell",     kf_cfg + kf_cmd + kf_cmd_early },
 };
 
 static struct {
@@ -1719,6 +1720,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_sethostname:
         if(f->is.numeric) config.net.sethostname = f->nvalue;
+        break;
+
+      case key_debugshell:
+        str_copy(&config.debugshell, *f->value ? f->value : NULL);
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -54,7 +54,7 @@ typedef enum {
   key_namescheme, key_ptoptions, key_is_ptoption, key_withfcoe, key_digests,
   key_plymouth, key_sslcerts, key_restart, key_restarted, key_autoyast2,
   key_withipoib, key_upgrade, key_ifcfg, key_defaultinstall, key_nanny, key_vlanid,
-  key_sshkey, key_systemboot, key_sethostname
+  key_sshkey, key_systemboot, key_sethostname, key_debugshell
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -470,6 +470,7 @@ typedef struct {
   char *change_config;		/* for 'change config option' input field */
   char *run_command;		/* for 'run command' input field */
   slist_t *defaultrepo;		/* default repo locations */
+  char *debugshell;		/* command to run if we want to start a shell for debugging */
 
   struct {
     unsigned md5:1;		/* support md5 */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -752,6 +752,8 @@ void lxrc_init()
 
   config.setupcmd = strdup("setctsid `showconsole` inst_setup yast");
 
+  config.debugshell = strdup("setctsid `showconsole` /bin/bash -l");
+
   config.update.map = calloc(1, MAX_UPDATES);
 
   config.zenconfig = strdup("settings.txt");

--- a/settings.c
+++ b/settings.c
@@ -598,7 +598,10 @@ int set_expert_cb(dia_item_t di)
           fflush(stdout);
         }
 
-        system("PS1='\\w # ' /bin/bash 2>&1");
+        char *cmd = NULL;
+        strprintf(&cmd, "PS1='\\w # ' %s 2>&1", config.debugshell ?: "/bin/sh");
+        system(cmd);
+        free(cmd);
 
         kbd_init(0);
         if(config.win) {


### PR DESCRIPTION
Also, make the actual shell command used configurable via debugshell option.