### PR TITLE
Add link to linux-devtools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ The package is automatically submitted from the `master` branch to
 [system:install:head](https://build.opensuse.org/package/show/system:install:head/linuxrc)
 OBS project. From that place it is forwarded to
 [openSUSE Factory](https://build.opensuse.org/project/show/openSUSE:Factory).
+
+You can find more information about this workflow in the [linuxrc-devtools
+documentation](https://github.com/openSUSE/linuxrc-devtools#opensuse-development).


### PR DESCRIPTION
Link to linuxrc-devtools documentation about openSUSE development.