### PR TITLE
set hostname to dhcp provided value per default (bsc #946047)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -806,6 +806,7 @@ void lxrc_init()
 
   config.ifcfg.manual = calloc(1, sizeof *config.ifcfg.manual);
   config.ifcfg.manual->dhcp = 1;
+  config.net.sethostname = 1;
 
   // config.nanny = 0;	/* see config.nanny_set */
 


### PR DESCRIPTION
After talking to Marius (mt) I chang the default and set the hostname via dhcp.

This will cause the ifcfg-files written by linuxrc to contain DHCLIENT_SET_HOSTNAME=yes.

You can still use the sethostname=0 boot option to revert this.