### PR TITLE
Do not limit number of inodes in tmpfs overlay

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -417,7 +417,7 @@ void lxrc_movetotmpfs()
     return;
   }
 
-  i = mount("tmpfs", newroot, "tmpfs", 0, "size=100%");
+  i = mount("tmpfs", newroot, "tmpfs", 0, "size=100%,nr_inodes=0");
   if(i) {
     perror(newroot);
     return;


### PR DESCRIPTION
On architectures like aarch64 which use 64k pagesize, we're
running very quickly against inode limits otherwise.