### PR TITLE
Made the following changes for FATE#320112

### DIFF
--- a/file.c
+++ b/file.c
@@ -1224,7 +1224,9 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         if(*f->value) str_copy(&config.hwp.userid, f->value);
         break;
       case key_portname:
-        str_copy(&config.hwp.portname, f->value);
+        log_show("***\n"); 
+        log_show("*** The Portname parameter is no longer needed. Please do not specify it.\n"); 
+        log_show("***\n"); 
         break;
       case key_readchan:
         if(*f->value) str_copy(&config.hwp.readchan, f->value);

--- a/global.h
+++ b/global.h
@@ -712,7 +712,6 @@ typedef struct {
     char* ccw_chan_ids;
     int ccw_chan_num;
     int protocol;
-    char* portname;
     int type;
     int interface;
     int layer2;

--- a/linuxrc.html
+++ b/linuxrc.html
@@ -1491,8 +1491,18 @@ Manual MAC address setting for Layer 2-enabled OSA devices. Note that this is di
 </td></tr>
 
 <tr>
+<td> OSAMedium </td><td>
+<p><i>deprecated</i>
+<p>Physical medium for OSA devices.
+</p><p>This parameter is no longer needed for any OSA device
+</p>
+</td></tr>
+
+<tr>
 <td> Portname </td><td>
+<p><i>deprecated</i>
 <p>Portname for OSA devices.
+</p><p>No network device needs or uses a portname any longer
 </p>
 </td></tr>
 

--- a/net.c
+++ b/net.c
@@ -1542,14 +1542,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
         if((rc=dia_input2_chopspace("Device address for data channel", &config.hwp.datachan, 9, 0))) return rc;
       if((rc=net_check_ccw_address(config.hwp.datachan))) return rc;
 
-      if (config.hwp.type != di_390net_hsi) {
-	  IFNOTAUTO(config.hwp.portname)
-	  {
-	      if((rc=dia_input2_chopspace("Portname to use", &config.hwp.portname,9,0))) return rc;
-	      // FIXME: warn about problems related to empty portnames
-	  }
-      }
-      
       IFNOTAUTO(config.hwp.layer2)
       {
         config.hwp.layer2 = dia_yesno("Enable OSI Layer 2 support?", YES) == YES ? LAYER2_YES : LAYER2_NO;
@@ -1618,10 +1610,7 @@ setup_ctc:
       ccmd += sprintf(ccmd, "qeth_configure ");
       if(config.hwp.portno)
         ccmd += sprintf(ccmd, "-n %d ", config.hwp.portno - 1);
-      ccmd += sprintf(ccmd, "%s%s%s %s %s %s %s 1",
-        config.hwp.portname ? "-p \"" : "",
-        config.hwp.portname ? config.hwp.portname : "",
-        config.hwp.portname ? "\"" : "",
+      ccmd += sprintf(ccmd, "%s %s %s %s 1",
         config.hwp.layer2 == LAYER2_YES ? "-l" : "",
         config.hwp.readchan,
         config.hwp.writechan,


### PR DESCRIPTION
Removed all the code that asks for an OSA Portname
If a Portname is found in the parameters, output a message saying it's deprecated
Updated linuxrc.html to indicate that Portname is deprecated
Updated linuxrc.html to also indicate that OsaMedium was deprecated, since people are still specifying it

Tested the changes on s390lp1