### PR TITLE
add 'linuxrcconfig' option to have linuxrc ask for install parameters  (fate #318899)

### DIFF
--- a/file.c
+++ b/file.c
@@ -309,6 +309,7 @@ static struct {
   { key_sethostname,    "SetHostname",    kf_cfg + kf_cmd_early          },
   { key_debugshell,     "DebugShell",     kf_cfg + kf_cmd + kf_cmd_early },
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
+  { key_config,         "LinuxrcConfig",  kf_cfg + kf_cmd_early          },
 };
 
 static struct {
@@ -1766,6 +1767,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
           str_copy(&config.self_update_url, f->value);
           config.self_update = 1;
         }
+        break;
+
+      case key_config:
+        if(f->is.numeric) config.config = f->nvalue;
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -54,7 +54,8 @@ typedef enum {
   key_namescheme, key_ptoptions, key_is_ptoption, key_withfcoe, key_digests,
   key_plymouth, key_sslcerts, key_restart, key_restarted, key_autoyast2,
   key_withipoib, key_upgrade, key_ifcfg, key_defaultinstall, key_nanny, key_vlanid,
-  key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update
+  key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
+  key_config
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -444,6 +444,7 @@ typedef struct {
   unsigned upgrade:1;		/* upgrade or fresh install */
   unsigned systemboot:1;	/* boot installed system */
   unsigned extend_running:1;	/* currently running an 'extend' job */
+  unsigned config:1;		/* show dialog asking for config options */
   struct {
     unsigned check:1;		/* check for braille displays and start brld if found */
     char *dev;			/* braille device */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1006,9 +1006,20 @@ void lxrc_init()
 
   LXRC_WAIT
 
-  log_show("Loading basic drivers...");
+  if(config.config) {
+    if(!dia_input2("Enter install parameters", &config.change_config, 70, 0)) {
+      file_t *f = file_parse_buffer(config.change_config, kf_cfg + kf_cmd + kf_cmd_early);
+      file_do_info(f, kf_cfg + kf_cmd + kf_cmd_early);
+      file_free_file(f);
+    }
+    if(!config.manual) util_disp_done();
+  }
+
+  LXRC_WAIT
+
+  log_show_maybe(!config.win, "Loading basic drivers...");
   mod_init(1);
-  log_show(" ok\n");
+  log_show_maybe(!config.win, " ok\n");
 
   LXRC_WAIT
 


### PR DESCRIPTION
This is atm just a proof-of-concept patch. Pass linuxrcconfig=1 as boot option to have
linuxrc itself show a dialog asking for install parameters.

This would be for systems where you don't have a chance to modify parameters via boot loader
(say s390x).

It would possibly even better if linuxrc could detect such a situation automatically...
