### PR TITLE
Updated the copyright information that is displayed on the console.

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -881,7 +881,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2015 SUSE LLC <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2016 SUSE LLC <<<\n",
       config.product
     );
     if (config.linemode)

--- a/net.c
+++ b/net.c
@@ -1548,7 +1548,10 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       }
       if(config.hwp.layer2 == LAYER2_YES) {
         IFNOTAUTO(config.hwp.osahwaddr) {
-          dia_input2("MAC address", &config.hwp.osahwaddr, 17, 1);
+          dia_info(&win, "Specifying a MAC address is optional.", MSGTYPE_INFO);
+          dia_info(&win, "In most cases letting it default is the correct choice.", MSGTYPE_INFO);
+          dia_info(&win, "Provide one only if you know it is truly necessary.", MSGTYPE_INFO);
+          dia_input2("Optional MAC address", &config.hwp.osahwaddr, 17, 1);
         }
       }
       

--- a/net.c
+++ b/net.c
@@ -1389,6 +1389,7 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
   char hwcfg_name[40];
   char* chans[3] = { config.hwp.readchan, config.hwp.writechan, config.hwp.datachan };
   char chanlist[27];
+  window_t win;
 
   if(hd) switch(hd->sub_class.id) {
   case 0x89:	/* OSA2 */

--- a/net.c
+++ b/net.c
@@ -1549,10 +1549,10 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       }
       if(config.hwp.layer2 == LAYER2_YES) {
         IFNOTAUTO(config.hwp.osahwaddr) {
-          dia_info(&win, "Specifying a MAC address is optional.", MSGTYPE_INFO);
-          dia_info(&win, "In most cases letting it default is the correct choice.", MSGTYPE_INFO);
-          dia_info(&win, "Provide one only if you know it is truly necessary.", MSGTYPE_INFO);
-          dia_input2("Optional MAC address", &config.hwp.osahwaddr, 17, 1);
+          dia_input2("Specifying a MAC address is optional.\n"\
+                     "In most cases letting it default is the correct choice.\n"\
+                     "Provide one only if you know it is truly necessary.\n"\
+                     "Optional MAC address", &config.hwp.osahwaddr, 17, 0);
         }
       }
       

--- a/net.c
+++ b/net.c
@@ -1389,7 +1389,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
   char hwcfg_name[40];
   char* chans[3] = { config.hwp.readchan, config.hwp.writechan, config.hwp.datachan };
   char chanlist[27];
-  window_t win;
 
   if(hd) switch(hd->sub_class.id) {
   case 0x89:	/* OSA2 */


### PR DESCRIPTION
Added verbiage to the prompt for the MAC address when a Layer 2 NIC
is being used. In most cases the user shouldn't specify one and take
the default.

This builds fine on all architectures and tested fine on s390x.