### PR TITLE
Added ifdefs and deleted various unused variables to eliminate compil…

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -35,7 +35,9 @@
 #include "checkmedia.h"
 
 static int driver_is_active(hd_t *hd);
+#if !defined(__s390__) && !defined(__s390x__)
 static void auto2_progress(char *pos, char *msg);
+#endif
 static void auto2_read_repo_files(url_t *url);
 static char *auto2_splash_name(void);
 static void auto2_kexec(url_t *url);
@@ -805,12 +807,14 @@ void load_drivers(hd_data_t *hd_data, hd_hw_item_t hw_item)
 /*
  * Default progress indicator for hardware probing.
  */
+#if !defined(__s390__) && !defined(__s390x__)
 void auto2_progress(char *pos, char *msg)
 {
   printf("\r%64s\r", "");
   printf("> %s: %s", pos, msg);
   fflush(stdout);
 }
+#endif
 
 
 char *auto2_serial_console()
@@ -937,7 +941,9 @@ void auto2_kexec(url_t *url)
   char *kernel, *initrd, *buf = NULL, *cmdline = NULL, *splash = NULL, *splash_name = NULL;
   FILE *f;
   int err = 0;
+#if defined(__i386__) || defined(__x86_64__)
   unsigned vga_mode = 0;
+#endif
 
   if(!config.kexec_kernel || !config.kexec_initrd) {
     log_info("no kernel and initrd for kexec specified\n");

--- a/net.c
+++ b/net.c
@@ -727,7 +727,7 @@ int net_choose_device()
         if ( ccw == -1 ) {
           /* IUCV device */
           if(hd->rom_id) strprintf(&annotation, "(%s)", hd->rom_id);
-          else strprintf(&annotation, "");
+          else strprintf(&annotation, " ");
         }
         else {
           strprintf(&annotation, "(%1x.%1x.%04x)", lcss >> 8, lcss & 0xf, ccw);
@@ -1379,11 +1379,7 @@ int net_s390_get_ifname(char* channel, char** device)
 
 int net_activate_s390_devs_ex(hd_t* hd, char** device)
 {
-  int rc, i;
-  char buf[100];
-  char hwcfg_name[40];
-  char* chans[3] = { config.hwp.readchan, config.hwp.writechan, config.hwp.datachan };
-  char chanlist[27];
+  int rc;
 
   if(hd) switch(hd->sub_class.id) {
   case 0x89:	/* OSA2 */
@@ -1639,8 +1635,6 @@ setup_ctc:
     struct ifreq ifr;
     struct ether_addr* ea;
     int skfd;
-    DIR* d;
-    struct dirent* de;
     char* ifname = NULL;
     
     net_s390_get_ifname(config.hwp.readchan, &ifname);

--- a/settings.c
+++ b/settings.c
@@ -92,8 +92,6 @@ static language_t set_languages_arm[] = {
   { lang_dummy, "", "us", NULL, NULL },
 };
 
-#define KEYMAP_DEFAULT	"us"
-
 #if !defined(__sparc__)
 static keymap_t set_keymaps_arm [] =
 {
@@ -157,7 +155,9 @@ static keymap_t set_keymaps_arm [] =
 #define NR_LANGUAGES (sizeof(set_languages_arm)/sizeof(set_languages_arm[0]))
 #define NR_KEYMAPS (sizeof(set_keymaps_arm)/sizeof(set_keymaps_arm[0]))
 
-#if defined(__PPC__)
+#if !defined(__PPC__)
+#define KEYMAP_DEFAULT	"us"
+#else
 #define KEYMAP_DEFAULT	"mac-us"
 static keymap_t set_keymaps_arm_mac [] =
 {


### PR DESCRIPTION
…er warnings.

Additionally there is an uninitialized use of the ip variable in linuxrc.c routine lxrc_catch_signal_11 because of a missing #ifdef for the aarch64 architecture.  I don't know what code to put there to set it properly, so I didn't try to patch it.