### PR TITLE
restore standard IO file descriptors when returning from external shell (bsc #983014)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -1508,27 +1508,7 @@ void dia_handle_ctrlc (void)
 	}
       }
       else if(i == -74) {
-        kbd_end(0);
-        if(config.win) {
-          disp_cursor_on();
-        }
-        if(!config.linemode) {
-          printf("\033c");
-          if(config.utf8) printf("\033%%G");
-          fflush(stdout);
-        }
-
-        char *cmd = NULL;
-        strprintf(&cmd, "exec %s 2>&1", config.debugshell ?: "/bin/sh");
-        system(cmd);
-        free(cmd);
-
-        kbd_init(0);
-        if(config.win) {
-          disp_cursor_off();
-          if(!config.linemode) disp_restore_screen();
-        }
-
+        util_run_debugshell();
       } else {
 	break;
       }

--- a/settings.c
+++ b/settings.c
@@ -587,26 +587,7 @@ int set_expert_cb(dia_item_t di)
        break;
 
     case di_extras_shell:
-        kbd_end(0);
-        if(config.win) {
-          disp_cursor_on();
-        }
-        if(!config.linemode) {
-          printf("\033c");
-          if(config.utf8) printf("\033%%G");
-          fflush(stdout);
-        }
-
-        char *cmd = NULL;
-        strprintf(&cmd, "PS1='\\w # ' %s 2>&1", config.debugshell ?: "/bin/sh");
-        system(cmd);
-        free(cmd);
-
-        kbd_init(0);
-        if(config.win) {
-          disp_cursor_off();
-          if(!config.linemode) disp_restore_screen();
-        }
+        util_run_debugshell();
       break;
 
     default:

--- a/util.c
+++ b/util.c
@@ -5457,3 +5457,40 @@ void util_set_hostname(char *hostname)
   log_info("set hostname: %s\n", hostname);
 }
 
+
+/*
+ * Run debug shell.
+ *
+ * This takes care of screen settings and restoring standard file
+ * descriptors.
+ */
+void util_run_debugshell()
+{
+  kbd_end(1);
+
+  if(config.win) {
+    disp_cursor_on();
+  }
+  if(!config.linemode) {
+    printf("\033c");
+    if(config.utf8) printf("\033%%G");
+    fflush(stdout);
+  }
+
+  char *cmd = NULL;
+  strprintf(&cmd, "exec %s 2>&1", config.debugshell ?: "/bin/sh");
+  system(cmd);
+  free(cmd);
+
+  freopen(config.console, "r", stdin);
+  freopen(config.console, "a", stdout);
+  freopen(config.console, "a", stderr);
+
+  kbd_init(0);
+
+  if(config.win) {
+    disp_cursor_off();
+    if(!config.linemode) disp_restore_screen();
+  }
+}
+

--- a/util.h
+++ b/util.h
@@ -156,3 +156,4 @@ int util_run(char *cmd, unsigned log_stdout);
 void util_perror(unsigned level, char *msg);
 char *util_get_caller(int skip);
 void util_set_hostname(char *hostname);
+void util_run_debugshell(void);


### PR DESCRIPTION
linuxrc was looping on closed stdin and writing to broken stdout. So, make sure IO works again when we return from sh.