### PR TITLE
fix reading instsys id (related to bsc #974601)

### DIFF
--- a/install.c
+++ b/install.c
@@ -1194,7 +1194,7 @@ int add_instsys()
     }
   }
 
-  file_read_info_file("/.instsys.config", kf_cfg);
+  file_read_info_file("file:/.instsys.config", kf_cfg);
 
   file_write_install_inf("");
 


### PR DESCRIPTION
instsys id reading didn't work due to this typo and so the check for the correct instsys didn't work.