### PR TITLE
make sure the correct interface is used when vlan is active (bsc #997913)

### DIFF
--- a/file.c
+++ b/file.c
@@ -1976,7 +1976,7 @@ void file_write_install_inf(char *dir)
   file_write_num(f, key_efi, config.efi >= 0 ? config.efi : config.efi_vars);
   if(config.net.dhcp_timeout_set) file_write_num(f, key_dhcptimeout, config.net.dhcp_timeout);
   file_write_num(f, key_configure_network, config.configure_network);
-  if(config.net.vlanid && strcmp(config.net.vlanid, "0")) {
+  if(net_vlanid_used()) {
     // if it's a nonzero value, pass it along
     file_write_str(f, key_vlanid, config.net.vlanid);
   }

--- a/net.h
+++ b/net.h
@@ -27,3 +27,8 @@ void net_apply_ethtool(char *device, char *hwaddr);
 void net_apply_iptool(char *device);
 int wlan_setup(void);
 
+void net_device_no_vlanid(void);
+void net_device_with_vlanid(void);
+int net_vlanid_used(void);
+void net_activate_main_interface_for_vlan(void);
+


### PR DESCRIPTION
[bsc#997913](https://bugzilla.suse.com/show_bug.cgi?id=997913)

Basically, ensure we operate on the correct interface. For this, append
before and remove after real network interface operations the '.vlanid'
appendix on the interface name (net.config.device variable).