### PR TITLE
don't configure ibft devices in linuxrc (bsc #997598)

### DIFF
--- a/file.c
+++ b/file.c
@@ -309,6 +309,7 @@ static struct {
   { key_sethostname,    "SetHostname",    kf_cfg + kf_cmd_early          },
   { key_debugshell,     "DebugShell",     kf_cfg + kf_cmd + kf_cmd_early },
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
+  { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
 };
 
 static struct {
@@ -1766,6 +1767,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
           str_copy(&config.self_update_url, f->value);
           config.self_update = 1;
         }
+        break;
+
+      case key_ibft_devices:
+        slist_assign_values(&config.ifcfg.ibft, f->value);
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -54,7 +54,8 @@ typedef enum {
   key_namescheme, key_ptoptions, key_is_ptoption, key_withfcoe, key_digests,
   key_plymouth, key_sslcerts, key_restart, key_restarted, key_autoyast2,
   key_withipoib, key_upgrade, key_ifcfg, key_defaultinstall, key_nanny, key_vlanid,
-  key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update
+  key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
+  key_ibft_devices
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -690,6 +690,7 @@ typedef struct {
     slist_t *if_up;		/* network interfaces != lo that are 'up' */
     char *current;		/* interface name for last written ifcfg file */
     slist_t *to_global;		/* keys that go to global /etc/sysconfig/network/config */
+    slist_t *ibft;		/* list of ibft interfaces (not to be configured by linuxrc) */
   } ifcfg;
 
   struct {

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -676,6 +676,7 @@ void lxrc_catch_signal(int signum)
 void lxrc_init()
 {
   int i;
+  slist_t *sl;
 
   siginterrupt(SIGALRM, 1);
   signal(SIGHUP, SIG_IGN);
@@ -963,6 +964,13 @@ void lxrc_init()
   net_wicked_get_config_keys();
 
   util_run_script("early_setup");
+
+  file_read_info_file("file:/etc/ibft_devices", kf_cfg);
+
+  // ibft interfaces are handled by wicked
+  for(sl = config.ifcfg.ibft; sl; sl = sl->next) {
+    slist_append_str(&config.ifcfg.initial, sl->key);
+  }
 
   if(config.plymouth) util_run_script("plymouth_setup");
 


### PR DESCRIPTION
We do this by asking wicked for ibft interfaces and adding them to
the 'initial' devices list. That list holds the interfaces that have a fixed
config that must not be modified by linuxrc.