### PR TITLE
parse netwait option earlier (bsc #995304)

### DIFF
--- a/file.c
+++ b/file.c
@@ -229,7 +229,7 @@ static struct {
   { key_portno,         "PortNo",         kf_cfg + kf_cmd                },
   { key_osahwaddr,	"OSAHWAddr",      kf_cfg + kf_cmd		 },
 #endif
-  { key_netwait,        "NetWait",        kf_cfg + kf_cmd                },
+  { key_netwait,        "NetWait",        kf_cfg + kf_cmd_early          },
   { key_newid,          "NewID",          kf_cfg + kf_cmd_early          },
   { key_moduledisks,    "ModuleDisks",    kf_cfg + kf_cmd                },
   { key_zen,            "Zen",            kf_cfg + kf_cmd + kf_cmd_early },


### PR DESCRIPTION
Obviously it needs to be parsed before we start to configure the network...