### PR TITLE
Clean up: removed "regcert", "smturl" and "smtcert" options (bsc#943966)

### DIFF
--- a/file.c
+++ b/file.c
@@ -273,9 +273,6 @@ static struct {
   { key_device,         "Device",         kf_cfg + kf_cmd                },
   { key_nomdns,         "NoMDNS",         kf_cfg + kf_cmd                },
   { key_yepurl,         "regurl",         kf_cfg + kf_cmd                },
-  { key_yepcert,        "regcert",        kf_cfg + kf_cmd                },
-  { key_yepurl,         "smturl",         kf_cfg + kf_cmd                },
-  { key_yepcert,        "smtcert",        kf_cfg + kf_cmd                },
   { key_mediacheck,     "mediacheck",     kf_cfg + kf_cmd_early          },
   { key_y2gdb,          "Y2GDB",          kf_cfg + kf_cmd                },
   { key_squash,         "squash",         kf_cfg + kf_cmd                },
@@ -1574,10 +1571,6 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         str_copy(&config.yepurl, f->value);
         break;
 
-      case key_yepcert:
-        str_copy(&config.yepcert, f->value);
-        break;
-
       case key_y2gdb:
         if(f->is.numeric) config.y2gdb = f->nvalue;
         break;
@@ -2005,7 +1998,6 @@ void file_write_modparms(FILE *f)
   }
 
   file_write_str(f, key_yepurl, config.yepurl);
-  file_write_str(f, key_yepcert, config.yepcert);
 
   file_write_str(f, key_supporturl, config.supporturl);
 

--- a/file.h
+++ b/file.h
@@ -47,7 +47,7 @@ typedef enum {
   key_ibft_hwaddr, key_ibft_ipaddr, key_ibft_netmask, key_ibft_gateway,
   key_ibft_dns, key_net_retry, key_bootif, key_swap_size, key_ntfs_3g,
   key_hash, key_insecure, key_kexec, key_nisdomain, key_nomodprobe, key_device,
-  key_nomdns, key_yepurl, key_yepcert, key_mediacheck, key_y2gdb, key_squash,
+  key_nomdns, key_yepurl, key_mediacheck, key_y2gdb, key_squash,
   key_kexec_reboot, key_devbyid, key_braille, key_nfsopts, key_ipv4, key_ipv4only,
   key_ipv6, key_ipv6only, key_efi, key_supporturl, key_portno,
   key_osahwaddr, key_zen, key_zenconfig, key_udevrule, key_dhcpfail,

--- a/global.h
+++ b/global.h
@@ -466,7 +466,6 @@ typedef struct {
   char *autoyast;		/* yast autoinstall parameter */
   char *autoyast2;		/* yast autoinstall parameter, loaded by linuxrc */
   char *yepurl;			/* just pass it to yast */
-  char *yepcert;		/* just pass it to yast */
   char *supporturl;		/* just pass it to yast */
   slist_t *linuxrc;		/* 'linuxrc' parameters */
   int color;			/* color scheme: 0-3: undef, mono, color, alternate */

--- a/linuxrc_yast_interface.txt
+++ b/linuxrc_yast_interface.txt
@@ -137,12 +137,6 @@ Hostname: %s
 # - code for this is at a strange place in linuxrc, should be moved -
 regurl: %s
 
-# certificates for registration server, use 'regcert' boot option to set
-# fate#303335
-# entry is missing if unset
-# - code for this is at a strange place in linuxrc, should be moved -
-regcert: %s
-
 # URL for uploadeing supportconfig data, use 'supporturl' boot option to set
 # fate#305180
 # entry is missing if unset


### PR DESCRIPTION
These options are not used in YaST anymore, removing the dead code.