### PR TITLE
add linuxrc.core option to enable core dumps in linuxrc (to debug bsc #1010505)

### DIFF
--- a/file.c
+++ b/file.c
@@ -307,6 +307,7 @@ static struct {
   { key_debugshell,     "DebugShell",     kf_cfg + kf_cmd + kf_cmd_early },
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
   { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
+  { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
 };
 
 static struct {
@@ -1764,6 +1765,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_ibft_devices:
         slist_assign_values(&config.ifcfg.ibft, f->value);
+        break;
+
+      case key_linuxrc_core:
+        str_copy(&config.core, *f->value ? f->value : NULL);
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -55,7 +55,7 @@ typedef enum {
   key_plymouth, key_sslcerts, key_restart, key_restarted, key_autoyast2,
   key_withipoib, key_upgrade, key_ifcfg, key_defaultinstall, key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices
+  key_ibft_devices, key_linuxrc_core
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -514,8 +514,10 @@ typedef struct {
   char *debugshell;		/**< command to run if we want to start a shell for debugging */
   slist_t *extern_scheme;	/**< externally handled URL schemes */
   slist_t *dia_extra_texts;	/**< dynamically defined dialog entries; cf. dia_get_text_id() */
-  char *self_update_url; /**< URL of YaST update for self-update */
-  unsigned self_update:1; /**< enables YaST self-update feature */
+  char *self_update_url;	/**< URL of YaST update for self-update */
+  unsigned self_update:1;	/**< enables YaST self-update feature */
+  char *core;			/**< linuxrc code dump destination (core dumps disabled if unset) */
+  unsigned core_setup:1;	/**< linuxrc core dumps have been configured */
 
   struct {
     unsigned md5:1;		/**< support md5 */

--- a/install.c
+++ b/install.c
@@ -26,8 +26,6 @@
 #include <sys/socket.h>
 #include <sys/reboot.h>
 #include <sys/vfs.h>
-#include <sys/time.h>
-#include <sys/resource.h>
 #include <arpa/inet.h>
 
 #include <hd.h>

--- a/install.c
+++ b/install.c
@@ -26,6 +26,8 @@
 #include <sys/socket.h>
 #include <sys/reboot.h>
 #include <sys/vfs.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <arpa/inet.h>
 
 #include <hd.h>

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -194,6 +194,8 @@ int main(int argc, char **argv, char **env)
       file_do_info(file_get_cmdline(key_tmpfs), kf_cmd + kf_cmd_early);
       file_do_info(file_get_cmdline(key_linuxrcstderr), kf_cmd + kf_cmd_early);
       file_do_info(file_get_cmdline(key_lxrcdebug), kf_cmd + kf_cmd_early);
+      file_do_info(file_get_cmdline(key_linuxrc_core), kf_cmd + kf_cmd_early);
+      util_setup_coredumps();
       util_free_mem();
       umount("/proc");
 
@@ -685,7 +687,7 @@ void lxrc_init()
   siginterrupt(SIGTERM, 1);
   siginterrupt(SIGSEGV, 1);
   siginterrupt(SIGPIPE, 1);
-  lxrc_catch_signal(0);
+  if(!config.core) lxrc_catch_signal(0);
   signal(SIGINT,  SIG_IGN);
   signal(SIGUSR1, lxrc_usr1);
 
@@ -712,6 +714,8 @@ void lxrc_init()
     mount("sysfs", "/sys", "sysfs", 0, 0);
     mount("devpts", "/dev/pts", "devpts", 0, 0);
   }
+
+  util_setup_coredumps();
 
   #if defined(__s390__) || defined(__s390x__)
   if(util_check_exist("/sys/hypervisor/s390")) {
@@ -884,6 +888,8 @@ void lxrc_init()
     slist_free(sl0);
   }
 
+  util_setup_coredumps();
+
   if(!config.had_segv) {
     if (config.linemode)
       putchar('\n');
@@ -942,6 +948,8 @@ void lxrc_init()
     util_run_script("udev_setup");
     log_show("ok\n");
   }
+
+  util_setup_coredumps();
 
   if(config.had_segv) config.manual = 1;
 

--- a/settings.c
+++ b/settings.c
@@ -401,7 +401,6 @@ void set_activate_language(enum langid_t lang_id)
 void set_activate_keymap(char *keymap)
 {
   char cmd[MAX_FILENAME];
-  char *s;
 
   /* keymap might be config.keymap, so be careful... */
   keymap = keymap ? strdup(keymap) : NULL;

--- a/util.h
+++ b/util.h
@@ -157,3 +157,4 @@ void util_perror(unsigned level, char *msg);
 char *util_get_caller(int skip);
 void util_set_hostname(char *hostname);
 void util_run_debugshell(void);
+void util_setup_coredumps(void);


### PR DESCRIPTION
It's used with either block or char dev as arg: linuxrc.core=block_dev|char_dev.
For a block dev, the device is mounted and core files created there. For a char dev,
the uuencoded core is written to it (think of serial line).