### PR TITLE
allow reading of config files from instsys location (/boot/ARCH/) (fate #322283)

### DIFF
--- a/linuxrc_repo.md
+++ b/linuxrc_repo.md
@@ -139,6 +139,7 @@ sub_part1: sub_sub_part11 sub_sub_part12 ...
 ```
 
 You can modify a part specification by:
+
 1. prefixing it with `?` to mark it optional
 2. appending `?list=path_spec1,path_spec2,...` to indicate you need not the
 full image but only the files matching any of the path specs (shell glob

--- a/url.c
+++ b/url.c
@@ -2279,12 +2279,9 @@ static int test_is_repo(url_t *url)
       }
       else {
         if(copy) {
-          char *argv[3];
           char *dst = strrchr(t, '/') ?: t;
           log_info("copy %s -> %s\n", buf, dst);
-          argv[1] = buf;
-          argv[2] = dst;
-          i = !util_cp_main(3, argv);
+          i = !util_cp_main(3, (char *[]) {0, buf, dst});
           ok &= i;
           if(!i) log_info("adding %s to instsys failed\n", dst);
         }


### PR DESCRIPTION
This works by extending the /boot/ARCH/config file syntax (see docs):

Appending '?copy=1' to a component tells linuxrc that this is not an image
to mount but a file to copy to the '/' directoy.