### PR TITLE
fix segfault when loading installer (bsc #1033441)

### DIFF
--- a/url.c
+++ b/url.c
@@ -935,6 +935,8 @@ void url_cleanup()
  * return:
  *   0: ok
  *   1: abort download
+ *
+ * Note: it's possible that 'done' follows 'init' without any 'update' in between.
  */
 int url_progress(url_data_t *url_data, int stage)
 {


### PR DESCRIPTION
There was a memory management issue when showing the progress bar window.
Already freed memory might have been reused.