### PR TITLE
read license.tar.gz from repomd repositories (fate #322286)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -925,7 +925,7 @@ void auto2_read_repomd_files(url_t *url)
     // be careful not to replace an existing file unless we successfully got
     // a new version
 
-    // first, get real file name
+    // get real file name
     slist_t *sl = slist_getentry(config.repomd_data, default_list[i][0]);
     if(!sl) continue;
 

--- a/auto2.c
+++ b/auto2.c
@@ -37,6 +37,7 @@
 static int driver_is_active(hd_t *hd);
 static void auto2_progress(char *pos, char *msg);
 static void auto2_read_repo_files(url_t *url);
+static void auto2_read_repomd_files(url_t *url);
 static char *auto2_splash_name(void);
 static void auto2_kexec(url_t *url);
 
@@ -601,7 +602,10 @@ int auto2_find_repo()
   }
 
   /* get some files for lazy yast */
-  if(!err) auto2_read_repo_files(config.url.install);
+  if(!err) {
+    if(config.repomd) auto2_read_repomd_files(config.url.install);
+    auto2_read_repo_files(config.url.install);
+  }
 
   if(err) {
     log_info("no %s repository found\n", config.product);
@@ -901,6 +905,41 @@ void auto2_read_repo_files(url_t *url)
       net_update_ifcfg(IFCFG_IFUP);
     }
   }
+}
+
+
+/*
+ * Get various files from repo-md repositrory for yast's convenience.
+ *
+ * Well, atm it's just license.tar.gz.
+ */
+void auto2_read_repomd_files(url_t *url)
+{
+  int i;
+  char *tmp_file = NULL;
+  static char *default_list[][2] = {
+    { "license", "/license.tar.gz" },
+  };
+
+  for(i = 0; i < sizeof default_list / sizeof *default_list; i++) {
+    // be careful not to replace an existing file unless we successfully got
+    // a new version
+
+    // first, get real file name
+    slist_t *sl = slist_getentry(config.repomd_data, default_list[i][0]);
+    if(!sl) continue;
+
+    str_copy(&tmp_file, new_download());
+    if(
+      !url_read_file(url, NULL, sl->value, tmp_file, NULL, URL_FLAG_NODIGEST) &&
+      util_check_exist(tmp_file)
+    ) {
+      rename(tmp_file, default_list[i][1]);
+      log_info("mv %s -> %s\n", tmp_file, default_list[i][1]);
+    }
+  }
+
+  str_copy(&tmp_file, NULL);
 }
 
 

--- a/file.c
+++ b/file.c
@@ -2565,7 +2565,7 @@ slist_t *file_parse_xmllike_buf(char *buf, char *tag)
   int i;
   char *ptr, *s0, *s1;
 
-  if(!tag || !buf) return sl0;
+  if(!tag || !buf || !*buf) return sl0;
 
   // we're going to modify the buffer
   buf = strdup(buf);
@@ -2646,8 +2646,6 @@ slist_t *file_parse_xmllike(char *name, char *tag)
   buf[buf_ptr] = 0;
 
   fclose(f);
-
-  if(!(buf_size = buf_ptr)) return sl0;
 
   sl0 = file_parse_xmllike_buf(buf, tag);
 

--- a/file.h
+++ b/file.h
@@ -105,4 +105,5 @@ file_t *file_parse_buffer(char *buf, file_key_flag_t flags);
 void file_do_info(file_t *f0, file_key_flag_t flags);
 void get_ide_options(void);
 slist_t *file_parse_xmllike(char *name, char *tag);
+void file_parse_repomd(char *file);
 

--- a/global.h
+++ b/global.h
@@ -445,6 +445,7 @@ typedef struct {
   unsigned upgrade:1;		/**< upgrade or fresh install */
   unsigned systemboot:1;	/**< boot installed system */
   unsigned extend_running:1;	/**< currently running an 'extend' job */
+  unsigned repomd:1;		/**< install repo is repo-md */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */
@@ -518,6 +519,7 @@ typedef struct {
   unsigned self_update:1;	/**< enables YaST self-update feature */
   char *core;			/**< linuxrc code dump destination (core dumps disabled if unset) */
   unsigned core_setup:1;	/**< linuxrc core dumps have been configured */
+  slist_t *repomd_data;		/**< parsed repomd.xml info */
 
   struct {
     unsigned md5:1;		/**< support md5 */

--- a/util.c
+++ b/util.c
@@ -1203,6 +1203,7 @@ void util_status_info(int log_it)
   add_flag(&sl0, buf, config.upgrade, "upgrade");
   add_flag(&sl0, buf, config.net.sethostname, "hostname");
   add_flag(&sl0, buf, config.self_update, "self_update");
+  add_flag(&sl0, buf, config.repomd, "repomd");
   if(*buf) slist_append_str(&sl0, buf);
 
   if(config.self_update_url) {
@@ -1582,11 +1583,20 @@ void util_status_info(int log_it)
     }
   }
 
+  if(config.repomd_data) {
+    strcpy(buf, "repomd-data:");
+    slist_append_str(&sl0, buf);
+    for(sl = config.repomd_data; sl; sl = sl->next) {
+      sprintf(buf, "  %s: %s", sl->key, sl->value);
+      slist_append_str(&sl0, buf);
+    }
+  }
+
   if(config.digests.list) {
     strcpy(buf, "digests:");
     slist_append_str(&sl0, buf);
     for(sl = config.digests.list; sl; sl = sl->next) {
-      sprintf(buf, "  %s %s", sl->key, sl->value);
+      sprintf(buf, "  %s: %s", sl->key, sl->value);
       slist_append_str(&sl0, buf);
     }
   }


### PR DESCRIPTION
This includes downloading and parsing repomd.xml to find ot the real file name
and file checksum.

This reuses the existing **very** limited xml parser file_parse_xmllike() which
seems sufficient here.