### PR TITLE
enforce linuxrc's maximum screen dimensions properly (bsc #1027354)

### DIFF
--- a/global.h
+++ b/global.h
@@ -83,7 +83,7 @@ enum langid_t {
 /* terminal sizes */
 #define X_DEFAULT		80
 #define Y_DEFAULT		24
-#define MAX_X			250
+#define MAX_X			500
 #define MAX_Y			150
 #define MIN_X			8
 #define MIN_Y			4

--- a/keyboard.c
+++ b/keyboard.c
@@ -84,6 +84,7 @@ static void kbd_set_timeout (long timeout_lv);
 static void kbd_timeout     (int signal_iv);
 
 static void get_screen_size(int fd);
+static void adjust_screen_size(void);
 
 
 /*
@@ -148,15 +149,7 @@ void kbd_init (int first)
     if(first && config.serial) {
       get_screen_size(config.kbd_fd);
 
-      if(max_x_ig > MAX_X) max_x_ig = MAX_X;
-      if(max_y_ig > MAX_Y) max_y_ig = MAX_Y;
-
-      if(max_x_ig < MIN_X || max_y_ig < MIN_Y) {
-        max_x_ig = X_DEFAULT;
-        max_y_ig = Y_DEFAULT;
-      }
-
-      if(!config.had_segv) log_info("Window size: %d x %d\n", max_x_ig, max_y_ig);
+      adjust_screen_size();
 
       memset(&winsize_ri, 0, sizeof winsize_ri);
 
@@ -164,6 +157,11 @@ void kbd_init (int first)
       winsize_ri.ws_row = max_y_ig;
 
       ioctl(config.kbd_fd, TIOCSWINSZ, &winsize_ri);
+    }
+
+    if(first) {
+      adjust_screen_size();
+      log_info("Window size: %d x %d\n", max_x_ig, max_y_ig);
     }
 
     }
@@ -527,5 +525,20 @@ void kbd_unimode()
   }
 
   if(fd >= 0) close(fd);
+}
+
+
+/*
+ * Clip screen size to maximum linuxrc can handle.
+ */
+void adjust_screen_size()
+{
+  if(max_x_ig > MAX_X) max_x_ig = MAX_X;
+  if(max_y_ig > MAX_Y) max_y_ig = MAX_Y;
+
+  if(max_x_ig < MIN_X || max_y_ig < MIN_Y) {
+    max_x_ig = X_DEFAULT;
+    max_y_ig = Y_DEFAULT;
+  }
 }
 


### PR DESCRIPTION
linuxrc uses static arrays for its textmode dialogs. The boundary check for
too large screens exsisted but was not always employed.