### PR TITLE
sort input files (boo#1041090)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
 BRANCH  := $(shell [ -d .git ] && git branch | perl -ne 'print $$_ if s/^\*\s*//')
 PREFIX  := linuxrc-$(VERSION)
 
-SRC	= $(filter-out inflate.c,$(wildcard *.c))
+SRC	= $(filter-out inflate.c,$(sort $(wildcard *.c)))
 INC	= $(wildcard *.h)
 OBJ	= $(SRC:.c=.o)
 


### PR DESCRIPTION
when building packages
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.

https://bugzilla.opensuse.org/show_bug.cgi?id=1041090