### PR TITLE
add SetHostnameUsed entry to install.inf (bsc #1054933)

### DIFF
--- a/file.c
+++ b/file.c
@@ -1747,7 +1747,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         break;
 
       case key_sethostname:
-        if(f->is.numeric) config.net.sethostname = f->nvalue;
+        if(f->is.numeric) {
+          config.net.sethostname = f->nvalue;
+          config.net.sethostname_used = 1;
+        }
         break;
 
       case key_debugshell:
@@ -1899,6 +1902,7 @@ void file_write_install_inf(char *dir)
     file_write_str(f, key_hostname, config.net.realhostname);
   }
   file_write_num(f, key_sethostname, config.net.sethostname);
+  fprintf(f, "SetHostnameUsed: %u\n", config.net.sethostname_used);
 
   LXRC_WAIT
 

--- a/global.h
+++ b/global.h
@@ -633,6 +633,7 @@ typedef struct {
     unsigned ipv6:1;		/**< do ipv6 config */
     unsigned dhcp_timeout_set:1;	/**< dhcp_timeout was set explicitly */
     unsigned sethostname:1;	/**< wicked should set hostname */
+    unsigned sethostname_used:1;	/**< user has used linuxrc's SetHostname option */
     unsigned do_setup;		/**< do network setup */
     unsigned setup;		/**< bitmask: do these network setup things */
     char *device;		/**< currently used device */

--- a/linuxrc_yast_interface.txt
+++ b/linuxrc_yast_interface.txt
@@ -136,6 +136,9 @@ Hostname: %s
 # in /etc/sysconfig/network/dhcp
 SetHostname: 0|1
 
+# 1: user has used SetHostname option to force a setting
+SetHostnameUsed: 0|1
+
 # URL for registration server, use 'regurl' boot option to set
 # fate#303335
 # entry is missing if unset


### PR DESCRIPTION
SetHostnameUsed is set if the user has used the SetHostname option
explicitly to change its value.

Note that this not only means via kernel command line but also includes
config files like linuxrc.config or an info file.