### PR TITLE
Fate322567

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1087,13 +1087,13 @@ void lxrc_init()
         mod_modprobe("zfcp","");
         if(util_read_and_chop("/sys/firmware/ipl/device", device, sizeof device))
         {
-          sprintf(cmd,"/sbin/zfcp_host_configure %s 1",device);
+          sprintf(cmd,"/sbin/chzdev -e zfcp-host %s",device);
           if(!config.test) lxrc_run(cmd);
           if(util_read_and_chop("/sys/firmware/ipl/wwpn", wwpn, sizeof wwpn))
           {
             if(util_read_and_chop("/sys/firmware/ipl/lun", lun, sizeof lun))
             {
-              sprintf(cmd,"/sbin/zfcp_disk_configure %s %s %s 1",device,wwpn,lun);
+              sprintf(cmd,"/sbin/chzdev -e zfcp-lun %s:%s:%s",device,wwpn,lun);
               if(!config.test) lxrc_run(cmd);
             }
           }

--- a/net.c
+++ b/net.c
@@ -1609,10 +1609,10 @@ setup_ctc:
     case di_390net_osa:
       if (config.hwp.interface == di_osa_lcs)
         goto setup_ctc;
-      ccmd += sprintf(ccmd, "/sbin/chzdev -e ");
+      ccmd += sprintf(ccmd, "/sbin/chzdev -e qeth ");
       if(config.hwp.portno)
         ccmd += sprintf(ccmd, "portno=%d ", config.hwp.portno - 1);
-      ccmd += sprintf(ccmd, "%s:%s:%s:%s ",
+      ccmd += sprintf(ccmd, "%s %s:%s:%s ",
         config.hwp.layer2 == LAYER2_YES ? "layer2=1 " : "",
         config.hwp.readchan,
         config.hwp.writechan,

--- a/net.c
+++ b/net.c
@@ -1601,19 +1601,19 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
     case di_390net_escon:
 setup_ctc:
       if(config.hwp.protocol > 0)
-        sprintf(cmd, "ctc_configure %s %s 1 %d", config.hwp.readchan, config.hwp.writechan, config.hwp.protocol - 1);
+        sprintf(cmd, "/sbin/chzdev -e ctc %s:%s protocol=%d", config.hwp.readchan, config.hwp.writechan, config.hwp.protocol - 1);
       else
-        sprintf(cmd, "ctc_configure %s %s 1", config.hwp.readchan, config.hwp.writechan);
+        sprintf(cmd, "/sbin/chzdev -e ctc %s %s", config.hwp.readchan, config.hwp.writechan);
       break;
     case di_390net_hsi:
     case di_390net_osa:
       if (config.hwp.interface == di_osa_lcs)
         goto setup_ctc;
-      ccmd += sprintf(ccmd, "qeth_configure ");
+      ccmd += sprintf(ccmd, "/sbin/chzdev -e ");
       if(config.hwp.portno)
-        ccmd += sprintf(ccmd, "-n %d ", config.hwp.portno - 1);
-      ccmd += sprintf(ccmd, "%s %s %s %s 1",
-        config.hwp.layer2 == LAYER2_YES ? "-l" : "",
+        ccmd += sprintf(ccmd, "portno=%d ", config.hwp.portno - 1);
+      ccmd += sprintf(ccmd, "%s:%s:%s:%s ",
+        config.hwp.layer2 == LAYER2_YES ? "layer2=1 " : "",
         config.hwp.readchan,
         config.hwp.writechan,
         config.hwp.datachan);


### PR DESCRIPTION
Persistent device configuration - installer part
Provide a common mechanism to achieve persistent configuration of System z devices that last across reboots and also integrates with the existing s390-tools.