### PR TITLE
Support for "media_upgrade" boot option (fate#323163), enabled Travis, added smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -t linuxrc-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it linuxrc-image rpm -qa | sort
+
+script:
+  - docker run --rm -it -e TRAVIS=1 linuxrc-image bash -c "make -j `nproc` && ./smoke_test.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM yastdevel/cpp
+
+RUN zypper --non-interactive in --no-recommends \
+  e2fsprogs-devel \
+  libblkid-devel \
+  libcurl-devel \
+  readline-devel \
+  tmux
+
+COPY . /usr/src/app

--- a/file.c
+++ b/file.c
@@ -297,6 +297,7 @@ static struct {
   { key_restarted,      "Restarted",      kf_cfg                         },
   { key_withipoib,      "WithIPoIB",      kf_cfg + kf_cmd_early          },
   { key_upgrade,        "Upgrade",        kf_cfg + kf_cmd                },
+  { key_media_upgrade,  "MediaUpgrade",   kf_cfg + kf_cmd                },
   { key_ifcfg,          "ifcfg",          kf_cfg + kf_cmd_early          },
   { key_defaultinstall, "DefaultInstall", kf_cfg + kf_cmd                },
   { key_defaultinstall, "DefaultRepo",    kf_cfg + kf_cmd                },
@@ -1709,6 +1710,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         if(f->is.numeric) config.upgrade = f->nvalue;
         break;
 
+      case key_media_upgrade:
+        if(f->is.numeric) config.media_upgrade = f->nvalue;
+        break;
+
       case key_ifcfg:
         if(*f->value) ifcfg_append(&config.ifcfg.list, ifcfg_parse(f->value));
         break;
@@ -1940,6 +1945,7 @@ void file_write_install_inf(char *dir)
   file_write_num(f, key_efi, config.efi >= 0 ? config.efi : config.efi_vars);
   file_write_num(f, key_insecure, !config.secure);
   if(config.upgrade) file_write_num(f, key_upgrade, config.upgrade);
+  if(config.media_upgrade) file_write_num(f, key_media_upgrade, config.media_upgrade);
   if(config.self_update_url)
     file_write_str(f, key_self_update, config.self_update_url);
   else if (config.self_update == 0 || config.self_update == 1)

--- a/file.h
+++ b/file.h
@@ -53,7 +53,8 @@ typedef enum {
   key_osahwaddr, key_zen, key_zenconfig, key_udevrule, key_dhcpfail,
   key_namescheme, key_ptoptions, key_is_ptoption, key_withfcoe, key_digests,
   key_plymouth, key_sslcerts, key_restart, key_restarted, key_autoyast2,
-  key_withipoib, key_upgrade, key_ifcfg, key_defaultinstall, key_nanny, key_vlanid,
+  key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
+  key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core
 } file_key_t;

--- a/git2log
+++ b/git2log
@@ -1,5 +1,14 @@
 #! /usr/bin/perl
 
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#
+# This script is maintained at https://github.com/openSUSE/linuxrc-devtools
+#
+# If you're in another project, this is just a copy.
+# You may update it to the latest version from time to time...
+#
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 use strict;
 
 use Getopt::Long;
@@ -10,206 +19,140 @@ $Data::Dumper::Terse = 1;
 $Data::Dumper::Indent = 1;
 
 sub usage;
-sub get_branch_tags;
-sub get_branch;
-sub get_parent_branch;
+sub changelog_outdated;
+sub get_github_project;
 sub get_version;
+sub get_tags;
+sub get_log;
+sub is_formatted_tag;
+sub get_branch;
+sub choose_tags;
+sub add_head_tag;
+sub tags_to_str;
+sub format_log;
+sub format_all_logs;
+sub fix_dates;
+sub add_line_breaks;
+sub format_date_obs;
+sub format_date_iso;
+sub raw_date_to_s;
 
 usage 0 if !@ARGV;
 
-my @deps = qw ( .git/HEAD .git/refs/heads .git/refs/tags );
+my @changelog_deps = qw ( .git/HEAD .git/refs/heads .git/refs/tags );
 
 my $branch;
 my $current_version;
 my @tags;
 my @all_tags;
+my $config;
 
 my $opt_log;
 my $opt_version;
 my $opt_branch;
 my $opt_update;
 my $opt_file;
+my $opt_start;
+my $opt_max;
+my $opt_width = 66;
+my $opt_width_fuzz = 8;
+my $opt_sep_width = 68;
+my $opt_format = 'internal';		# obs, internal
+my $opt_merge_msg_before = 1;		# log auto generated pr merge message before the commit messages (vs. after)
+my $opt_join_author = 1;		# join consecutive commit messages as long as they are by the same author
+my $opt_keep_date = 1;			# don't join consecutive commit messages if they have different time stamps
 
 GetOptions(
   'help'          => sub { usage 0 },
   'version'       => \$opt_version,
   'branch'        => \$opt_branch,
   'update'        => \$opt_update,
+  'start=s'       => \$opt_start,
+  'format=s'      => \$opt_format,
+  'max=i'         => \$opt_max,
+  'width=i'       => \$opt_width,
+  'fuzz=i'        => \$opt_width_fuzz,
+  'merge-msg=s'   => sub { $opt_merge_msg_before = ($_[1] eq 'after' ? 0 : 1) },
+  'join-author!'  => \$opt_join_author,
+  'keep-date!'    => \$opt_keep_date,
   'log|changelog' => \$opt_log,
 ) || usage 1;
 
+# ensure we are used correctly
 usage 1 if @ARGV > 1 || !($opt_log || $opt_version || $opt_branch);
 $opt_file = @ARGV ? shift : '-';
 
 die "no git repo\n" unless -d ".git";
 
-if($opt_update && $opt_file ne '-' && -f($opt_file)) {
-  my $ok = 1;
+# if update option has been give write changelog only if git refs are newer
+exit 0 if $opt_update && $opt_file ne '-' && -f($opt_file) && !changelog_outdated($opt_file);
 
-  my $t = (stat $opt_file)[9];
+$opt_max = 2 if $opt_version || $opt_branch;
 
-  for (@deps) {
-    $ok = 0 if (stat)[9] > $t;
-  }
+# gather some data
+get_github_project;
+get_branch;
+get_log;
+fix_dates;
+get_tags;
+choose_tags;
+add_head_tag;
+get_version;
 
-  exit 0 if $ok;
-}
-
-@all_tags = `git tag`;
-chomp @all_tags;
-
-$branch = get_branch;
-die "no branch?\n" unless $branch;
-
-@tags = get_branch_tags;
-die "no tags at all?\n" unless @tags;
-
-if($branch ne 'master') {
-  if(!grep { /^$branch\-/ } @tags) {
-    $branch = get_parent_branch;
-    die "sorry, can't determine branch\n" unless $branch;
-
-    @tags = get_branch_tags;
-    die "no tags at all?\n" unless @tags;
-  }
-}
-else {
-  @tags = get_branch_tags;
-  die "no tags at all?\n" unless @tags;
-}
-
+# just print current branch
 if($opt_branch) {
   open my $f, ">$opt_file";
-  print $f "$branch\n";
+  print $f $config->{branch} ? $config->{branch} : "master", "\n";
   close $f;
 
   exit 0;
 }
 
-$current_version = get_version;
-
+# just print current version
 if($opt_version) {
-  open my $f, ">$opt_file";
-  print $f "$current_version\n";
-  close $f;
+  my $old_version;
+
+  if($opt_file ne '-' && open(my $f, $opt_file)) {
+    chomp($old_version = <$f>);
+    close $f;
+  }
+
+  if($config->{version} ne $old_version) {
+    open my $f, ">$opt_file";
+    print $f "$config->{version}\n";
+    close $f;
+  }
 
   exit 0;
 }
 
-if($branch ne 'master') {
-  my ($i1, $i2, $bi);
-
-  for (my $i = 0; $i < @tags; $i++) {
-    if($tags[$i] =~ /^$branch\-(\S+)/) {
-      $i2 = $i;
-      $bi = $1;
-      last;
-    }
-  }
-
-  # print STDERR ">> $branch-$bi\n";
-
-  warn "no tags in this branch yet\n" unless $bi;
-
-  for (my $i = 0; $i < $i2; $i++) {
-    if($tags[$i] ge $bi) {
-      if($tags[$i] eq $bi) {
-        $i1 = $i;
-      }
-      elsif($i > 0) {
-        $i1 = $i - 1;
-      }
-      last;
-    }
-  }
-
-  splice @tags, $i1, $i2 - $i1;
+# set start tag
+if($opt_start) {
+  my $x = is_formatted_tag $opt_start;
+  die "$opt_start: not a valid start tag\n" if !$x;
+  $x->{branch} = $config->{branch} if !$x->{branch};
+  $config->{start} = $x;
 }
 
-map { s/(\d+)/$1 + 0/eg } @tags;
+format_all_logs;
 
-push @tags, "HEAD";
+open my $f, ">$opt_file";
 
-# print Dumper(\@tags);
+print $f $_->{formatted} for @{$config->{log}};
 
-open F, ">$opt_file";
+close $f;
 
-for (my $i = @tags - 1; $i > 0; $i--) {
-  my ($date, @t2);
-
-  my @t = `git log --pretty=medium --date=iso '$tags[$i-1]..$tags[$i]'`;
-
-  # print "\n--- $tags[$i-1]..$tags[$i] ---\n", @t, "---\n";
-
-  my $merge = 0;
-  for (@t) {
-    $merge = 1 if /^Merge: /;
-    $merge = 0 if /^commit /;
-    push @t2, $_ if !$merge;
-  }
-  @t = @t2;
-
-  undef @t2;
-  my $detail = 0;
-  for (@t) {
-    $detail = 1 if /^    $/;
-    $detail = 2 if /^    Conflicts:$/;
-    $detail = 0 if /^commit /;
-    if(!$detail) {
-      push @t2, $_ if $detail < 2;
-    }
-  }
-  @t = @t2;
-
-  # print "\n--- $tags[$i-1]..$tags[$i] ---\n", @t;
-
-  chomp @t;
-  for (@t) {
-    if(/^Date:\s*(\S+)/) {
-      $date = $1;
-      last;
-    }
-  }
-
-  # handle white space in every first line once and for all
-  my $empty = 1;
-  for (@t) {
-    $empty = 1, $_ = "", next if $_ =~ /^\s*$/;
-    next if !$empty;
-    s/^\s*//;
-    $empty = 0;
-  }
-
-  @t = grep { !/^(commit|Author:|Date:|Merge:|\s*$)|created.*tag/ } @t;
-  if(@t) {
-    # rewrite a bit to have it look more consistent
-    map { s/(fate|bnc|bsc)#/$1 #/g } @t;
-    map { s/(fate|bnc|bsc)\s*(\d{4})/$1 #$2/g } @t;
-    map { s/\(#/(bnc #/g } @t;
-    map { s/bug\s*#/bnc #/g } @t;
-    map { s/feat(\.|ure)?\s*#?(\d+)/fate #$2/g } @t;
-    map { s/^ {4}// } @t;
-    map { s/^ {8}// } @t;
-    map { s/^ +/  / } @t;
-    map { s/^\s*[+\-][\-\s]*/- / } @t;
-    map { s/^([^ \-])/- $1/ } @t;
-    map { s/^/\t/ } @t;
-    map { s/\\'/'/ } @t;
-
-    # print "\n--- $tags[$i-1]..$tags[$i] ---\n", join("\n", @t);
-
-    my $t = $tags[$i];
-    $t = "${branch}-$t" if $branch ne 'master' && $t eq "HEAD";
-    $t =~ s/HEAD/$current_version/;
-    print F "$date:\t$t\n";
-    print F join("\n", @t), "\n\n";
-  }
-}
-
-close F;
+exit 0;
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# usage(exit_code)
+#
+# Print help message and exit.
+# - exit_code: exit code
+#
+# Function does not return.
+#
 sub usage
 {
   my $err = shift;
@@ -217,11 +160,23 @@ sub usage
   print <<"  usage";
 Usage: git2log [OPTIONS] [FILE]
 Create changelog and project version from git repo.
-  --changelog   Write changelog to FILE.
-  --version     Write version number to FILE.
-  --branch      Write current branch to FILE.
-  --update      Write changelog or version only if FILE is outdated.
-  --help        Print this help text.
+  --changelog         Write changelog to FILE.
+  --version           Write version number to FILE.
+  --branch            Write current branch to FILE.
+  --start START_TAG   Start with tag START_TAG.
+  --max N             Write at most MAX long entries.
+  --update            Write changelog or version only if FILE is outdated.
+  --format FORMAT     Write log using FORMAT. Supported FORMATs are 'internal' (default) and 'obs'.
+  --width WIDTH       Reformat log entries to be max WIDTH chars wide.
+  --fuzz FUZZ         Allow log lines to be up to FUZZ chars longer as WIDTH to avoid
+                      line breaks leaving tiny bits on the last line.
+  --merge-msg WHERE   Log message about merges before or after the actual merge commit messages.
+                      Valid values for WHERE are 'after' and 'before' (default).
+  --join-author       Join consecutive commits as long as they are by the same author. (default)
+  --no-join-author    Keep consecutive commits by the same author separate.
+  --keep-date         Join consecutive commits only if they have the same date. (default)
+  --no-keep-date      Join consecutive commits even if dates differ.
+  --help              Print this help text.
   usage
 
   exit $err;
@@ -229,70 +184,753 @@ Create changelog and project version from git repo.
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub get_branch_tags
+# res = changelog_outdated(file)
+#
+# Return status of changelog file.
+# - file: changelog file name
+# - res: status
+#     1: file is newer than the last git repo change and should be updated
+#     0: file is still recent enough
+#
+# Relies on global var @changelog_deps.
+#
+sub changelog_outdated
 {
-  my @ntags;
+  my $file = $_[0];
 
-  for (@all_tags) {
-    if(/^\d/) {
-      s/(\d+)/sprintf "%04d", $1/eg;
-      push @ntags, $_;
-    }
-    elsif(s/^$branch\-//) {
-      s/(\d+)/sprintf "%04d", $1/eg;
-      push @ntags, "$branch-$_";
-    }
+  my $changelog_time = (stat $file)[9];
+
+  return 1 if !defined $changelog_time;
+
+  for (@changelog_deps) {
+    return 1 if (stat)[9] > $changelog_time;
   }
 
-  return sort @ntags;
+  return 0;
 }
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub get_branch
+# get_github_project()
+#
+# Set $config->{github_project} to the github project name.
+#
+sub get_github_project
 {
-  my $b;
-
-  for (`git branch`) {
-    if(/^\*\s+(\S+)/) {
-      $b = $1;
-      last;
-    }
+  if(`git config remote.origin.url` =~ m#github.com[:/]+(\S+/\S+)#) {
+    $config->{github_project} = $1;
+    $config->{github_project} =~ s/\.git$//;
   }
-
-  $b = "master" if $b eq '(no';
-
-  return $b;
 }
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub get_parent_branch
-{
-  my $p;
-
-  for (`git log -g --pretty=oneline`) {
-    $p = $1 if /checkout: moving from (\S+) to $branch/;
-  }
-
-  # print "parent = $p\n";
-
-  return $p || "master";
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_version()
+#
+# Set $config->{branch} and $config->{version} to the current branch and
+# version info.
+#
+# This might be taken directly from HEAD if HEAD is tagged or otherwise be
+# exprapolated from the most recent tag (cf. add_head_tag()).
+#
 sub get_version
 {
-  my $v = $tags[-1];
-  $v =~ s/(\d+)/$1 + 0/eg;
+  $config->{version} = "0.0";
 
-  if(`git log --pretty=medium --date=iso '$v..HEAD'`) {
-    $v =~ s/(\d+)$/$1 + 1/e;
+  my $tag = $config->{log}[0]{tags}[0];
+
+  if($tag->{version}) {
+    $config->{version} = $tag->{version};
+    $config->{branch} = $tag->{branch};
   }
-
-  $v =~ s/^$branch\-//;
-
-  return $v;
 }
 
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_tags()
+#
+# Parse $config->{raw_log}, extract tag names, and split into per-tag
+# sections.
+#
+# Only tags recognized by is_formatted_tag() are considered.
+#
+# The parsed logs is stored in $config->{log}, an array of log sections.
+# Each section is a hash with these keys:
+#   - 'tags': array of tags for this section
+#   - 'commit': git commit id associated with these tags
+#   - 'lines': git log lines
+#
+sub get_tags
+{
+  my $log_entry;
+
+  for (@{$config->{raw_log}}) {
+    if(/^commit (\S+)( \((.*)\))?/) {
+      my $commit = $1;
+      my $tag_list = $3;
+      my $xtag;
+
+      for my $t (split /, /, $tag_list) {
+        if($t =~ /tag: (\S+)/) {
+          my $tag = $1;
+          my $x = is_formatted_tag $tag;
+          push @$xtag, $x if $x;
+        }
+      }
+
+      if($xtag) {
+        if($log_entry) {
+          push @{$config->{log}}, $log_entry;
+          last if $opt_max && @{$config->{log}} >= $opt_max;
+        }
+        $log_entry = { commit => $commit, tags => $xtag };
+      }
+      else {
+        $log_entry = { commit => $commit } if !$log_entry;
+      }
+    }
+
+    push @{$log_entry->{lines}}, $_ if $log_entry;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_log()
+#
+# Read git log and store lines as array in $config->{raw_log} (trailing
+# newlines removed).
+#
+sub get_log
+{
+  chomp(@{$config->{raw_log}} = `git log --pretty=medium --date=raw --topo-order --decorate`);
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# hash_ref = is_formatted_tag(tag_name)
+#
+# Parse tag and return hash ref with branch and version number parts or
+# undef if it doesn't match.
+# - tag_name: tag as string
+# - hash_ref: hash ref with internal tag representation (with keys 'branch' and 'version').
+#
+# This expects tags of the form "VERSION" or "BRANCH-VERSION" where VERSION
+# consists of decimal numbers separated by dots '.' and BRANCH can be any
+# string.
+# (Note: it doesn't really have to be the name of an existing branch.)
+#
+# Tags not conforming to this convention are ignored.
+#
+sub is_formatted_tag
+{
+  if($_[0] =~ /^((.+)-)?((\d+\.)*\d+)$/) {
+    return { branch => $2, version => $3 }
+  }
+
+  return undef;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_branch()
+#
+# Get currently active git branch and store in $config->{branch}.
+#
+# 'master' branch is represented by empty 'branch' key.
+#
+sub get_branch
+{
+  chomp(my $branch = `git rev-parse --abbrev-ref HEAD`);
+
+  $branch = "" if $branch eq 'master';
+
+  $config->{branch} = $branch;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# res = tag_sort(a, b)
+#
+# Compare 2 tags.
+# - a, b: refs to tag hash
+# - res: -1, 0, 1
+#
+# This is used when we have to decide between alternative tags.
+# (Prefer 'lesser' variant.)
+#
+sub tag_sort
+{
+  my ($x, $y);
+
+  $x = length $a->{version};
+  $y = length $b->{version};
+
+  # longer version number first
+  return $y <=> $x if $y <=> $x;
+
+  return $a->{branch} cmp $b->{branch};
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# str = tag_to_str(tag_ref)
+#
+# Convert tag into string.
+# - tag_ref: ref to hash with 'branch' and 'version' keys
+# - str: string (e.g. "foo-1.44")
+#
+# 'master' branch is represented by missing/empty 'branch' key.
+#
+sub tag_to_str
+{
+  my $tag = $_[0];
+  my $str;
+
+  $str = "$tag->{branch}-" if $tag->{branch} ne "";
+  $str .= $tag->{version};
+
+  return $str;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# str = tags_to_str(tag_array_ref)
+#
+# Convert array of tags into string.
+# - tag_array_ref: ref to array of tags
+# - str: string (e.g. "(tag1, tag2)"
+#
+# This function is used only internally for debugging.
+#
+sub tags_to_str
+{
+  my $tags = $_[0];
+  my $str;
+
+  for my $t (@$tags) {
+    $str .= ", " if $str;
+    $str .= tag_to_str $t;
+  }
+
+  return "($str)";
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# choose_tags()
+#
+# Scan commit messages and extract tag & branch information.
+#
+# This stores the tag/branch info in $config->{log}[]{tags}.
+#
+sub choose_tags
+{
+  my $branch = $config->{branch};
+
+  for my $x (@{$config->{log}}) {
+    # printf "# %s\n", tags_to_str($x->{tags});
+
+    # no tag info? -> ignore
+    next if !$x->{tags};
+
+    # single tag? -> remember branch info
+    if(@{$x->{tags}} == 1) {
+      $branch = $x->{tags}[0]{branch};
+      next;
+    }
+
+    # several tags? -> choose one
+
+    # any with current branch name?
+    my @t = grep { $_->{branch} eq $branch } @{$x->{tags}};
+
+    # no? -> choose among all
+    @t = @{$x->{tags}} if @t == 0;
+
+    # prefer longest version number, then alphanumerically smallest branch name
+    @t = sort tag_sort @t;
+
+    $branch = $t[0]{branch};
+    $x->{tags} = [ $t[0] ];
+
+    # printf "X %s\n", tags_to_str($x->{tags});
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# add_head_tag()
+#
+# Suggest tag for HEAD if there isn't one.
+#
+# Basically, use branch + version from most recent tag and increment version.
+#
+sub add_head_tag
+{
+  return if @{$config->{log}} < 2;
+
+  # HEAD tagged already?
+  return if $config->{log}[0]{tags};
+
+  # the first tagged commit if HEAD isn't tagged
+  my $tag = { %{$config->{log}[1]{tags}[0]} };
+
+  # increment version
+  $tag->{version} =~ s/(\d+)$/$1 + 1/e;
+
+  $config->{log}[0]{tags}[0] = $tag;
+
+  # remember that the tag was generated
+  $config->{log}[0]{was_untagged} = 1;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# fix_dates()
+#
+# Adjust time stamps in entire git log.
+#
+# The time stamps of the git commits are not necessarily ordered by date.
+# But the generated changelog is required to have a monotonic time.
+#
+# We do this by going through the log in reverse and rewriting any dates we
+# find whenever the date decreases.
+#
+# Not very subtle but it works.
+#
+sub fix_dates
+{
+  my $last_date;
+
+  for (reverse @{$config->{raw_log}}) {
+    # e.g. "Date: 1443184889 +0200"
+    if(/^(Date:\s+)(\S+)(\s+\S+)/) {
+      if(defined $last_date && $2 < $last_date) {
+        $_ = "$1$last_date$3\n";
+        next;
+      }
+    }
+    $last_date = $2;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# format_all_logs()
+#
+# Format the entire git log.
+#
+# This is done for every code version individually (the log has already been
+# split accordingly).
+#
+# If $config->{start} is set, use this as starting point. Else format the
+# entire git log.
+#
+sub format_all_logs
+{
+  # check if start tag actually exists - if not, print nothing
+  if($config->{start}) {
+    my $tag_found;
+    for (@{$config->{log}}) {
+      $tag_found = 1, last if grep { tag_to_str($config->{start}) eq tag_to_str($_) } @{$_->{tags}};
+    }
+    return if !$tag_found;
+  }
+
+  for (@{$config->{log}}) {
+    if($config->{start}) {
+      # stop if we meet the start tag
+      last if grep { tag_to_str($config->{start}) eq tag_to_str($_) } @{$_->{tags}};
+    }
+    format_log $_;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# format_log(log)
+#
+# Format log messages.
+# - log: is an array ref with individual commits
+#
+# All commits belong to a specific code version (stored in $log->{tag}).
+# $log->{formatted} holds the result.
+#
+# The process is done in several individual steps, documented below in the code.
+#
+sub format_log
+{
+  my $log = $_[0];
+
+  my $merge;
+  my $commit;
+  my $saved_commit;
+  my $commits;
+
+  for (@{$log->{lines}}) {
+    if(/^commit (\S+)/) {
+      $commit = { ref => $1 };
+      push @{$commits}, $commit;
+
+      if(
+        $merge &&
+        $merge->{merge_end} eq substr($commit->{ref}, 0, length($merge->{merge_end}))
+      ) {
+        undef $merge;
+      }
+
+      if($merge) {
+        $commit->{merge_ref} = $merge->{ref};
+        $commit->{date} = $merge->{date};
+        # add to all commits so it's not lost when we re-arrange
+        $commit->{merge_msg} = $merge->{msg} if $merge->{msg};
+        # saved entry no longer needed
+        undef $saved_commit;
+      }
+
+      next;
+    }
+
+    if(/^Merge: (\S+)/) {
+      if($commit) {
+        $merge = { merge_end => $1, ref => $commit->{ref} } unless $merge;
+        $saved_commit = pop @{$commits};
+      }
+      undef $commit;
+      next;
+    }
+
+    if(/^Date:\s+(\S.*)/) {
+      if($commit) {
+        $commit->{date} = $1 if !$commit->{date};
+      }
+      elsif($merge) {
+        $merge->{date} = $1 if !$merge->{date};
+      }
+      next;
+    }
+
+    if(/^Author:\s+(\S.*)/) {
+      $commit->{author} = $1 if $commit;
+      $merge->{author} = $1 if $merge && !$merge->{author};
+      next;
+    }
+
+    if($commit) {
+      push @{$commit->{lines}}, $_ if s/^    //;
+    }
+    elsif($merge && !$merge->{msg}) {
+      if(/^    Merge pull request (#\d+) from (\S+)/) {
+        if($config->{github_project}) {
+          $merge->{msg} = "merge gh#$config->{github_project}$1";
+        }
+        else {
+          $merge->{msg} = "merge pr $2";
+        }
+      }
+      elsif(/^    Merge branch '([^']+)'/) {
+        $merge->{msg} = "merge branch $1";
+      }
+    }
+  }
+
+  # it can happen that there's a lonely merge commit left at the end
+  if($merge && $saved_commit) {
+    $saved_commit->{merge_ref} = $merge->{ref};
+    $saved_commit->{date} = $merge->{date};
+    $saved_commit->{author} = $merge->{author};
+    $saved_commit->{merge_msg} = $merge->{msg} if $merge->{msg};
+    $saved_commit->{formatted} = [];
+
+    push @{$commits}, $saved_commit;
+  }
+
+  # Note: the individual steps below work on the array @$commits and modify
+  # its content.
+
+  # step 1
+  # - if there are paragraphs starting with '@log@' or '@+log@'
+  #     - delete first paragraph (short summary)
+  # - else
+  #     - keep only first paragraph
+  # - if there is a paragraph starting with '@-log', delete entire log
+  # - tag commits that have a '@log@' tag so we can delete untagged commits
+  #   belonging to the same merge commit later
+
+  my $tagged_merges = {};
+
+  for my $commit (@$commits) {
+    my $para_cnt = 0;
+    my $delete_all = 0;
+    my $delete_first = 0;
+    for (@{$commit->{lines}}) {
+      $para_cnt++ if $_ eq "";
+      $para_cnt = 0, $delete_first = 1 if /^\@\+log\@/;
+      $delete_all = 1 if /^\@\-log\@/;
+      if(/^\@log\@/) {
+        $para_cnt = 0;
+        $commit->{clear} = 1;
+        $tagged_merges->{$commit->{merge_ref}} = 1 if $commit->{merge_ref} || $log->{was_untagged};
+      }
+      $_ = undef if $para_cnt;
+    }
+    shift @{$commit->{lines}} if $delete_first;
+    $commit->{lines} = [] if $delete_all;
+  }
+
+  # step 2
+  # - clean up tagged commits or commits belonging to tagged merges
+
+  for my $commit (@$commits) {
+    next unless $commit->{clear} || $tagged_merges->{$commit->{merge_ref}};
+    for (@{$commit->{lines}}) {
+      last if /^\@\+?log\@/;
+      $_ = undef;
+    }
+  }
+
+  # step 3
+  # - join lines
+
+  for my $commit (@$commits) {
+    my $lines;
+    my $line;
+
+    for (@{$commit->{lines}}) {
+      next if $_ eq "";
+      if(
+        s/^\s*[+\-][\-\s]*// ||
+        s/^\@\+?log\@// ||
+        $line eq ""
+      ) {
+        s/^\s*//;
+        push @$lines, $line if $line ne "";
+        $line = $_;
+      }
+      else {
+        s/^\s*//;
+        $line .= " " if $line ne "";
+        $line .= $_;
+      }
+    }
+    push @$lines, $line if $line ne "";
+
+    $commit->{formatted} = $lines if $lines;
+  }
+
+  # step 4
+  # - fix small glitches
+
+  for my $commit (@$commits) {
+    next unless $commit->{formatted};
+    for (@{$commit->{formatted}}) {
+      s/(fate|bnc|bsc)\s*(#\d+)/\L$1\E$2/ig;
+    }
+  }
+
+  # step 5
+  # - add merge info at the top or bottom (depending on $opt_merge_msg_before)
+
+  my $merge_logged;
+
+  for my $commit ($opt_merge_msg_before ? reverse(@$commits) : @$commits) {
+    next unless $commit->{formatted};
+
+    if($commit->{merge_ref} && !$merge_logged->{$commit->{merge_ref}}) {
+      $merge_logged->{$commit->{merge_ref}} = 1;
+      if($commit->{merge_msg}) {
+        if($opt_merge_msg_before) {
+          unshift @{$commit->{formatted}}, $commit->{merge_msg};
+        }
+        else {
+          push @{$commit->{formatted}}, $commit->{merge_msg};
+        }
+      }
+    }
+  }
+
+  # step 6
+  # - join commit messages with same author (optionally even with different dates)
+
+  my $commit0;
+
+  for my $commit (@$commits) {
+    next if !$commit->{formatted};
+    $commit0 = $commit, next if !$commit0;
+
+    if(
+      # $commit->{merge_ref} eq $commit0->{merge_ref} &&
+      (
+        $opt_join_author && ($commit->{author} eq $commit0->{author})
+        && (!$opt_keep_date || $commit->{date} eq $commit0->{date})
+      )
+      || $opt_format eq 'internal'
+    ) {
+      unshift @{$commit0->{formatted}}, @{$commit->{formatted}};
+      delete $commit->{formatted};
+    }
+    else {
+      $commit0 = $commit;
+    }
+  }
+
+  # step 7
+  # - add version tag at the end of the first log entry
+
+  for my $commit (@$commits) {
+    next unless $commit->{formatted};
+
+    if($opt_format eq 'obs') {
+      push @{$commit->{formatted}}, $log->{tags}[0]{version} if defined $log->{tags}[0]{version};
+    }
+    else {
+      # push @{$commit->{formatted}}, tag_to_str($log->{tags}[0]);
+    }
+
+    last;
+  }
+
+  # step 8
+  # - add line breaks
+
+  for my $commit (@$commits) {
+    next unless $commit->{formatted};
+    for (@{$commit->{formatted}}) {
+      $_ = add_line_breaks $_;
+    }
+  }
+
+  # step 9
+  # - generate final log message
+  #
+  # note: non-(open)suse email addresses are replaced by a generic
+  # 'opensuse-packaging@opensuse.org'
+
+  my $formated_log;
+
+  for my $commit (@$commits) {
+    next unless $commit->{formatted} && @{$commit->{formatted}};
+
+    if($opt_format eq 'obs') {
+      $formated_log .= "-" x $opt_sep_width . "\n";
+      $formated_log .= format_date_obs($commit->{date});
+    }
+    else {
+      $formated_log .= format_date_iso($commit->{date});
+    }
+    if($opt_format eq 'obs') {
+      my $auth = $commit->{author};
+      $auth =~ s/^.*<//;
+      $auth =~ s/>.*$//;
+      # replace non-suse e-mail addresses with a generic one
+      if($auth !~ /\@(suse\.(com|cz|de)|opensuse\.org)$/) {
+        $auth = 'opensuse-packaging@opensuse.org'
+      }
+      $formated_log .= " - $auth\n\n";
+    }
+    else {
+      $formated_log .= ":\t" . tag_to_str($log->{tags}[0]) . "\n";
+    }
+
+    for (@{$commit->{formatted}}) {
+      s/^/\t/mg if $opt_format eq 'internal';
+      $formated_log .= "$_\n";
+    }
+
+    $formated_log .= "\n";
+  }
+
+  $log->{formatted} = $formated_log;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# new_text = add_line_breaks(text)
+#
+# Add line breaks to text.
+# - text: some text
+# - new_text: same text, reformatted
+#
+# Lines are formatted to have a maximal length of $opt_width. If this causes
+# the last line to be shorter than $opt_width_fuzz, it is appended to the
+# previous line.
+#
+sub add_line_breaks
+{
+  my @words = split /\s+/, @_[0];
+  my $remaining_len = length(join '', @words);
+
+  my $str = shift(@words);
+  my $len = length $str;
+
+  my $next_len;
+  my $word_len;
+
+  for (@words) {
+    $word_len = length;
+    $remaining_len -= $word_len;
+    $next_len = $len + $word_len + 1;
+    if(
+      $next_len >= $opt_width &&
+      $next_len + $remaining_len + 1 >= $opt_width + $opt_width_fuzz
+    ) {
+      $str .= "\n  $_";
+      $len = $word_len;
+    }
+    else {
+      $str .= " $_";
+      $len += $word_len + 1;
+    }
+  }
+
+  return "- " . $str;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# seconds = raw_date_to_s(git_date)
+#
+# Convert git raw date to seconds.
+# - git_date: raw git format (e.g. "1443184889 +0200")
+# - seconds: the seconds part (e.g. "1443184889")
+#
+sub raw_date_to_s
+{
+  return (split / /, $_[0])[0];
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# date = format_date_obs(git_date)
+#
+# Convert git raw date to obs format.
+# - git_date: raw git format (e.g. "1443184889 +0200")
+# - date: obs format ("Fri Sep 25 12:41:29 UTC 2015")
+#
+sub format_date_obs
+{
+  my @d = gmtime(raw_date_to_s($_[0]));
+
+  return
+    qw(Sun Mon Tue Wed Thu Fri Sat)[$d[6]] . " " .
+    qw(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)[$d[4]] . " " .
+    $d[3] . " " .
+    sprintf("%02d:%02d:%02d", $d[2], $d[1], $d[0]) . " UTC " .
+    (1900 + $d[5]);
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# date = format_date_iso(git_date)
+#
+# Convert git raw date to iso format.
+# - git_date: raw git format (e.g. "1443184889 +0200")
+# - date: obs format ("2015-09-25")
+#
+sub format_date_iso
+{
+  my @d = gmtime(raw_date_to_s($_[0]));
+
+  return sprintf("%04d-%02d-%02d", 1900 + $d[5], $d[4] + 1, $d[3]);
+}

--- a/global.h
+++ b/global.h
@@ -443,6 +443,7 @@ typedef struct {
   unsigned nanny:1;		/**< use wickedd-nanny */
   unsigned nanny_set:1;		/**< nanny setting was changed */
   unsigned upgrade:1;		/**< upgrade or fresh install */
+  unsigned media_upgrade:1;	/**< upgrade using media */
   unsigned systemboot:1;	/**< boot installed system */
   unsigned extend_running:1;	/**< currently running an 'extend' job */
   unsigned repomd:1;		/**< install repo is repo-md */

--- a/keyboard.c
+++ b/keyboard.c
@@ -310,7 +310,7 @@ void check_for_key(int del_garbage)
 /*
  * Read keyboard input until some key sequence has been recognized.
  */
-int kbd_getch_raw(do_wait)
+int kbd_getch_raw(int do_wait)
 {
   unsigned char key;
   int i, esc_delay, time_to_wait, esc_count, delay;

--- a/linuxrc_yast_interface.txt
+++ b/linuxrc_yast_interface.txt
@@ -269,6 +269,12 @@ EFI: %d
 # entry is missing if unset (0)
 Upgrade: 1
 
+# 1: YaST should do an upgrade using media (without using a registration server)
+# This setting is ignored if "Upgrade" option is not set, the option alone
+# does not trigger the upgrade mode in YaST.
+# entry is missing if unset (0)
+MediaUpgrade: 1
+
 # set via 'rootpassword' boot option
 # if set to 'ask', linuxrc will show a dialog asking for a password
 # this should be used a temporary root password for the target system

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,0 +1,127 @@
+#! /bin/sh
+
+# exit on error immediately
+set -e
+
+function start_command()
+{
+  echo "Starting command '$2'..."
+  # run the command in a new tmux session (-d = detach, -s = session name)
+  # force 80x25 terminal size
+  TERM=screen tmux new-session -d -s "$1" -x 80 -y 25 $2
+}
+
+function dump_screen()
+{
+  echo "----------------------- Screen Dump Begin -----------------------------"
+  if [ "$TRAVIS" == "1" ]; then
+    # the sed call transforms spaces to non-breakable UTF-8 spaces because
+    # Travis does not display a normal space sequence correctly
+    tmux capture-pane -e -p -t "$1" | sed 's/ /\xC2\xA0/g'
+  else
+    tmux capture-pane -e -p -t "$1"
+  fi
+  # reset the terminal to restore the initial color settings
+  # (might be changed by the color dump)
+  tput init
+  echo "----------------------- Screen Dump End -------------------------------"
+}
+
+function expect_text()
+{
+  if tmux capture-pane -p -t "$1" | grep -q "$2"; then
+    echo "Matched expected text: '$2'"
+  else
+    echo "ERROR: No match for expected text '$2'"
+    exit 1
+  fi
+}
+
+function not_expect_text()
+{
+  if tmux capture-pane -p -t "$1" | grep -q "$2"; then
+    echo "ERROR: Matched unexpected text: '$2'"
+    exit 1
+  fi
+}
+
+function send_keys()
+{
+  echo "Sending keys: $2"
+  tmux send-keys -t "$1" "$2"
+}
+
+function process_exited()
+{
+  if tmux has-session "$1" 2> /dev/null; then
+    echo "ERROR: The process is still running!"
+    exit 1
+  else
+    echo "The process exited, OK"
+  fi
+}
+
+# name of the tmux session
+SESSION=linuxrc
+
+###############################################################################
+
+# run linuxrc in line mode in a new session
+start_command $SESSION "./linuxrc linemode=1"
+
+# wait a bit to ensure it is up
+# TODO: wait until the screen contains the expected text (with a timeout),
+# 5 seconds might not be enough on a slow or overloaded machine
+sleep 5
+dump_screen $SESSION
+
+expect_text $SESSION "Please make sure your installation medium is available"
+
+# quit via hidden extra menu
+send_keys $SESSION "x"
+send_keys $SESSION "Enter"
+
+sleep 3
+dump_screen $SESSION
+expect_text $SESSION "Linuxrc extras"
+expect_text $SESSION "5) Quit linuxrc"
+send_keys $SESSION "5"
+send_keys $SESSION "Enter"
+
+sleep 3
+process_exited $SESSION
+
+###############################################################################
+
+# run linuxrc in standard mode in a new session
+start_command $SESSION ./linuxrc
+
+# wait a bit to ensure it is up
+# TODO: wait until the screen contains the expected text (with a timeout),
+# 5 seconds might not be enough on a slow or overloaded machine
+sleep 5
+dump_screen $SESSION
+expect_text $SESSION "Please make sure your installation medium is available"
+
+# FIXME: ??? sending Ctrl+C for some reason does not work in Travis,
+# so kill the process and finish here
+if [ "$TRAVIS" == "1" ]; then
+  echo "Travis environment set, stopping the test..."
+  kill -9 `pidof linuxrc`
+  exit 0
+fi
+
+# quit via Ctrl+C...
+send_keys $SESSION "C-c"
+
+sleep 3
+dump_screen $SESSION
+expect_text $SESSION "You cannot exit Linuxrc"
+# then use hidden q
+send_keys $SESSION "q"
+
+sleep 3
+process_exited $SESSION
+
+# TODO: trap the signals and do a cleanup at the end
+# (kill the process if it is still running, use tmux kill-session ?)

--- a/util.c
+++ b/util.c
@@ -1201,6 +1201,7 @@ void util_status_info(int log_it)
   add_flag(&sl0, buf, config.withfcoe, "fcoe");
   add_flag(&sl0, buf, config.withipoib, "ipoib");
   add_flag(&sl0, buf, config.upgrade, "upgrade");
+  add_flag(&sl0, buf, config.media_upgrade, "media_upgrade");
   add_flag(&sl0, buf, config.net.sethostname, "hostname");
   add_flag(&sl0, buf, config.self_update, "self_update");
   add_flag(&sl0, buf, config.repomd, "repomd");


### PR DESCRIPTION
### Summary

- Added a new handler for the `media_upgrade` boot option ([fate#323163](https://fate.suse.com/323163))
- Added a basic Travis support (does not build the RPM, just compiles the sources), but at least something...
- The `git2log` script has been updated to handle detached Git HEAD in Travis build (just updated from the [linuxrc-devtools](https://github.com/openSUSE/linuxrc-devtools) repository)

### Travis Smoke Test

Added a simple smoke test to ensure `linuxrc` can be started and does not crash.

  - The test covers both the line mode and the interactive mode
  -  See an [example Travis log](https://travis-ci.org/openSUSE/linuxrc/builds/291400319#L975) for the result
  - Unfortunately Travis does not display the screen dump well, but it is still somehow readable (the colors are bit broken, too big line spacing, the output contains some broken UTF-8 characters), when running locally it looks correctly
  - Also I could not find why sending the `Ctrl+C` keyboard combination in Travis does not work, when running the Docker build locally it works. So there is a small hack to finish the linuxrc interactive test earlier when `TRAVIS` environment variable is set.

### Testing 

Tested manually using the `mksusecd` script, when booted with `upgrade=1 media_upgrade=1` then the `/etc/install.inf` contains the expected values:

![linuxrc_media_upgrade](https://user-images.githubusercontent.com/907998/31876929-c9a3f0ea-b7d4-11e7-881d-e730659edcf8.png)
