### PR TITLE
update broken module config even if list is empty

### DIFF
--- a/file.c
+++ b/file.c
@@ -1008,7 +1008,7 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_brokenmodules:
         slist_assign_values(&config.module.broken, f->value);
-        if(config.module.broken && !config.test) {
+        if(!config.test) {
           if((w = fopen("/etc/modprobe.d/blacklist.conf", "w"))) {
             for(sl = config.module.broken; sl; sl = sl->next) {
               if(sl->key) fprintf(w, "blacklist %s\n", sl->key);


### PR DESCRIPTION
Otherwise you'll never be able to clear the list entirely.

see https://bugzilla.suse.com/show_bug.cgi?id=1058065#c10