### PR TITLE
Don't include RPC headers if we don't need them. RPC is deprecated in…

### DIFF
--- a/net.c
+++ b/net.c
@@ -15,10 +15,6 @@
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <dirent.h>
-#include <rpc/rpc.h>
-#include <rpc/pmap_prot.h>
-#include <rpc/pmap_clnt.h>
-#include <rpcsvc/mount.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
Don't include RPC headers if we don't need them. RPC is deprecated in glibc.

Signed-off-by: Thorsten Kukuk <kukuk@thkukuk.de>