### PR TITLE
Support reading AutoYaST profile from the QEMU fw_cfg

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -910,6 +910,16 @@ void auto2_read_repo_files(url_t *url)
       log_info("parsing AutoYaST file\n");
       file_read_info_file("file:/autoinst.xml", kf_cfg);
       net_update_ifcfg(IFCFG_IFUP);
+    } else if(util_check_exist("/sys/firmware/qemu_fw_cfg/by_name/opt/com.suse/autoinst/raw") == 'r') {
+      /*
+       * check if an autoyast profile was passed from the firmware interface
+       * if no autoyast= is given and no /autoinst.xml override exists.
+       */
+       log_info("Using AutoYaST profile from QEMU firmware config interface.\n");
+       str_copy(&config.autoyast, "file:///sys/firmware/qemu_fw_cfg/by_name/opt/com.suse/autoinst/raw");
+       log_info("parsing AutoYaST file\n");
+       file_read_info_file("file:/sys/firmware/qemu_fw_cfg/by_name/opt/com.suse/autoinst/raw", kf_cfg);
+       net_update_ifcfg(IFCFG_IFUP);
     }
   }
 }


### PR DESCRIPTION
See: https://git.qemu.org/?p=qemu.git;a=blob;f=docs/specs/fw_cfg.txt

In order to pass the profile to the VM, the following QEMU command
line is used: -fw_cfg name=opt/keyname,file=somedata.txt

For the AutoYaST support, the key "opt/com.suse/autoinst" is used.
So: -fw_cfg name=opt/com.suse/autoinst,file=autoinst.xml

It is used as last resort, to allow overriding it with the media and
the kernel command line options.

TODO: document at https://en.opensuse.org/SDB:Linuxrc#AutoYaST_Profile_Handling if merged.

Reviewer note: I could had factored out some common code (parsing and network), however, giving the quirk of the parse function working with `file:/` but not `file:///` it was not possible to use `config.autoyast` there, so the refactoring not worth it.