### PR TITLE
read digests also from CHECKSUMS file

### DIFF
--- a/file.h
+++ b/file.h
@@ -107,4 +107,5 @@ void file_do_info(file_t *f0, file_key_flag_t flags);
 void get_ide_options(void);
 slist_t *file_parse_xmllike(char *name, char *tag);
 void file_parse_repomd(char *file);
+void file_parse_checksums(char *file);
 

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -894,7 +894,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2016 SUSE LLC <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2017 SUSE LLC <<<\n",
       config.product
     );
     if (config.linemode)

--- a/linuxrc_repo.md
+++ b/linuxrc_repo.md
@@ -79,12 +79,19 @@ get warnings about linuxrc not being able to verify the downloaded images.
 
 Lets see how to avoid this.
 
-### 2.1. solving the digest problem
+### 2.1. getting file digests
 
-As there's no longer a `content` file, linuxrc needs to get the digests in
-some other way. Fortunately it parses `content` just like any other config
-file, so you can simply copy it into linuxrc's config directory and add that
-to the initrd.
+There is no longer a `content` file. Instead, there is now a `CHECKSUMS`
+file (with sligthly different format) containing sha256 digests of
+repository files.
+
+`CHECKSUMS` must be signed (detached signature in `CHECKSUMS.ASC`).
+
+linuxrc gets the digests from two locations:
+- a `content` file included in the initrd at installation system build time (placed directly into linuxrc's config directory)
+- `CHECKSUMS` from the repo location
+
+To include `content` in the initrd in a place linuxrc finds it, do something like:
 
 ```sh
 mkdir -p /tmp/foo/etc/linuxrc.d

--- a/url.c
+++ b/url.c
@@ -2178,9 +2178,10 @@ static int test_is_repo(url_t *url)
   if(!config.keepinstsysconfig) {
     config.digests.failed = 0;
 
-    // check for '/content' or '/repodata/repomd.xml' as indication we have a suse repo
-    // 'content' must be validly signed (we parse it), 'repomd.xml' not (we just check its presence)
-    // zenworks has a different approach ('settings.txt') - they don't have a repo
+    // Check for '/content' resp. '/repodata/repomd.xml' as indication we
+    // have a SUSE repo.
+    // The file must be validly signed (because we parse it).
+    // zenworks has a different approach ('settings.txt') - they don't have a repo.
 
     strprintf(&buf, "/%s", config.zen ? config.zenconfig : "content");
     strprintf(&buf2, "file:%s", buf);
@@ -2206,6 +2207,15 @@ static int test_is_repo(url_t *url)
       config.repomd = 1;
 
       file_parse_repomd("/repomd.xml");
+
+      // download CHECKSUMS ...
+      read_failed = url_read_file(
+        url, NULL, "/CHECKSUMS", "/CHECKSUMS", NULL,
+        URL_FLAG_NODIGEST + (config.secure ? URL_FLAG_CHECK_SIG : 0)
+      );
+
+      // ... and parse it
+      if(!read_failed) file_parse_checksums("/CHECKSUMS");
     }
 
     if(!config.sig_failed && util_check_exist(buf)) {


### PR DESCRIPTION
The new media layout has a 'CHECKSUMS' file instead of the old 'content'.