### PR TITLE
allow kexec to work with secure boot (bsc #1075051)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -1037,7 +1037,7 @@ void auto2_kexec(url_t *url)
 
     sync();
 
-    strprintf(&buf, "kexec -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
+    strprintf(&buf, "kexec -s -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
 
     if(!config.test) {
       lxrc_run(buf);

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -894,7 +894,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2017 SUSE LLC <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2018 SUSE LLC <<<\n",
       config.product
     );
     if (config.linemode)

--- a/util.c
+++ b/util.c
@@ -5203,7 +5203,7 @@ void util_boot_system()
   }
 
   strprintf(&buf,
-    "kexec -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
+    "kexec -s -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
     kernel_name, initrd_name, kernel_options
   );
 


### PR DESCRIPTION
For this, the -s option should be used. See discussion in [bsc \#1075051](https://bugzilla.suse.com/show_bug.cgi?id=1075051) for details.