### PR TITLE
extend 'kexec' option to allow updating kernel/initrd only if necessary (bsc #990374)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -39,7 +39,6 @@ static void auto2_progress(char *pos, char *msg);
 static void auto2_read_repo_files(url_t *url);
 static void auto2_read_repomd_files(url_t *url);
 static char *auto2_splash_name(void);
-static void auto2_kexec(url_t *url);
 
 static int test_and_add_dud(url_t *url);
 
@@ -595,7 +594,7 @@ int auto2_find_repo()
   /* now go and look for repo */
   err = url_find_repo(config.url.install, config.mountpoint.instdata);
 
-  if(!err && config.kexec) {
+  if(!err && config.kexec == 1) {
     auto2_kexec(config.url.install);
     log_info("kexec failed\n");
     return 0;
@@ -1041,6 +1040,7 @@ void auto2_kexec(url_t *url)
 
     if(!config.test) {
       lxrc_run(buf);
+      LXRC_WAIT
       util_umount_all();
       sync();
       lxrc_run("kexec -e");

--- a/auto2.h
+++ b/auto2.h
@@ -10,3 +10,4 @@ int auto2_remove_extension(char *extension);
 void load_drivers(hd_data_t *hd_data, hd_hw_item_t hw_item);
 void auto2_user_netconfig(void);
 void auto2_user_netconfig(void);
+void auto2_kexec(url_t *url);

--- a/global.h
+++ b/global.h
@@ -419,7 +419,6 @@ typedef struct {
   unsigned secure_always_fail:1;	/**< in secure mode: never ask the user but always fail directly */
   unsigned sslcerts:1;		/**< whether to check ssl certificates */
   unsigned sig_failed:2;	/**< signature check failed (1: not signed, 2: wrong signature) */
-  unsigned kexec:1;		/**< kexec to kernel & initrd from repo */
   unsigned kexec_reboot:1;	/**< kexec to installed system (just passed to yast) */
   unsigned nomodprobe:1;	/**< disable modprobe */
   unsigned y2gdb:1;		/**< pass to yast */
@@ -521,6 +520,12 @@ typedef struct {
   char *core;			/**< linuxrc code dump destination (core dumps disabled if unset) */
   unsigned core_setup:1;	/**< linuxrc core dumps have been configured */
   slist_t *repomd_data;		/**< parsed repomd.xml info */
+  unsigned kexec;		/**< kexec to kernel & initrd from repo (if inst-sys does not match)
+                                 * 0: never
+                                 * 1: always
+                                 * 2: if necessary, with user dialog (default)
+                                 * 3: if necessary, no user dialog
+                                 */
 
   struct {
     unsigned md5:1;		/**< support md5 */

--- a/install.c
+++ b/install.c
@@ -1209,10 +1209,35 @@ int add_instsys()
     int win;
 
     if(!(win = config.win)) util_disp_init();
+
+    /*
+     * config.kexec settings:
+     *   2: ask user whether to load kernel
+     *   3: load kernel without user confirmation
+     *
+     * Note: config.kexec == 1 is handled in auto2_find_repo(); we never get
+     * here in this case.
+     */
+    if(
+      config.kexec == 3 ||
+      (
+        config.kexec == 2 &&
+        YES == dia_yesno(
+          "To use the selected repository a matching boot image is needed.\n"
+          "\n"
+          "Download it now and restart?",
+          YES
+        )
+      )
+    ) {
+      auto2_kexec(config.url.install);
+      log_info("kexec failed\n");
+    }
+
     if(config.instsys_complain == 1) {
       dia_message(
         "Installation system does not match your boot medium.\n\n"
-        "It may make your bugreports worthless.",
+        "This may cause problems and make your bugreports worthless.",
         MSGTYPE_ERROR
       );
     }

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -799,6 +799,7 @@ void lxrc_init()
   config.efi = -1;
   config.udev_mods = 1;
   config.devtmpfs = 1;
+  config.kexec = 2;		/* kexec if necessary, with user dialog */
 
   // defaults for self-update feature
   config.self_update_url = NULL;

--- a/url.c
+++ b/url.c
@@ -2227,7 +2227,7 @@ static int test_is_repo(url_t *url)
     str_copy(&buf2, NULL);
   }
 
-  if(config.url.instsys->scheme != inst_rel || config.kexec) return 1;
+  if(config.url.instsys->scheme != inst_rel || config.kexec == 1) return 1;
 
   if(!config.keepinstsysconfig) {
     instsys_config = url_instsys_config(config.url.instsys->path);


### PR DESCRIPTION
This patch adds
- kexec=2: check if instsys does not match, then present a user dialog
- kexec=3: check, but skip the dialog

The default is now kexec=2.