### PR TITLE
be carefull with 'kexec -s', it's not always available (bsc #1076839)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -1036,7 +1036,14 @@ void auto2_kexec(url_t *url)
 
     sync();
 
-    strprintf(&buf, "kexec -s -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
+    // sometimes you need it, sometimes not - see bsc#1076839
+    #if defined(__x86_64__)
+      #define KEXEC_OPT	" -s"
+    #else
+      #define KEXEC_OPT ""
+    #endif
+
+    strprintf(&buf, "kexec" KEXEC_OPT " -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
 
     if(!config.test) {
       lxrc_run(buf);

--- a/util.c
+++ b/util.c
@@ -5202,8 +5202,15 @@ void util_boot_system()
     return;
   }
 
+  // sometimes you need it, sometimes not - see bsc#1076839
+  #if defined(__x86_64__)
+    #define KEXEC_OPT	" -s"
+  #else
+    #define KEXEC_OPT	""
+  #endif
+
   strprintf(&buf,
-    "kexec -s -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
+    "kexec" KEXEC_OPT " -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
     kernel_name, initrd_name, kernel_options
   );
 


### PR DESCRIPTION
Until upstream comes around we need a working solution. Until then, pass
different parameters to kexec.