### PR TITLE
kexec uses '-a' option now (bsc #1076839)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -1036,14 +1036,7 @@ void auto2_kexec(url_t *url)
 
     sync();
 
-    // sometimes you need it, sometimes not - see bsc#1076839
-    #if defined(__x86_64__)
-      #define KEXEC_OPT	" -s"
-    #else
-      #define KEXEC_OPT ""
-    #endif
-
-    strprintf(&buf, "kexec" KEXEC_OPT " -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
+    strprintf(&buf, "kexec -a -l %s --initrd=%s --append='%s kexec=0'", kernel, initrd, cmdline);
 
     if(!config.test) {
       lxrc_run(buf);

--- a/util.c
+++ b/util.c
@@ -5202,15 +5202,8 @@ void util_boot_system()
     return;
   }
 
-  // sometimes you need it, sometimes not - see bsc#1076839
-  #if defined(__x86_64__)
-    #define KEXEC_OPT	" -s"
-  #else
-    #define KEXEC_OPT	""
-  #endif
-
   strprintf(&buf,
-    "kexec" KEXEC_OPT " -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
+    "kexec -a -l '/mnt/%s' --initrd='/mnt/%s' --append='%s'",
     kernel_name, initrd_name, kernel_options
   );
 


### PR DESCRIPTION
Finally: you always have to use the new '-a' option.