### PR TITLE
don't impose limits on /proc/cmdline size (bsc #1092154)

### DIFF
--- a/file.c
+++ b/file.c
@@ -2067,6 +2067,7 @@ file_t *file_read_cmdline(file_key_flag_t flags)
   FILE *f;
   file_t *ft;
   char **argv, *cmdline = NULL;
+  size_t cmdline_len = 0;
 
   if(config.test) {
     if(!config.had_segv) {
@@ -2077,8 +2078,7 @@ file_t *file_read_cmdline(file_key_flag_t flags)
   }
   else {
     if(!(f = fopen(CMDLINE_FILE, "r"))) return NULL;
-    cmdline = calloc(1024, 1);
-    if(!fread(cmdline, 1, 1023, f)) *cmdline = 0;
+    getdelim(&cmdline, &cmdline_len, 0, f);
     fclose(f);
   }
 


### PR DESCRIPTION
Apparently 1024 is not enough - so let's not assume any limit.

The same as https://github.com/openSUSE/linuxrc/pull/171 but for sle12-sp3+.