### PR TITLE
setctsid is dead, long live setsid (bsc #1109290)

### DIFF
--- a/install.c
+++ b/install.c
@@ -1367,7 +1367,7 @@ int inst_execute_yast()
   str_copy(&setupcmd, config.setupcmd);
 
   if(config.url.install->scheme == inst_exec) {
-    strprintf(&setupcmd, "setctsid `showconsole` %s",
+    strprintf(&setupcmd, "setsid -wc %s",
       *config.url.install->path ? config.url.install->path : "/bin/sh"
     );
   }

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -762,9 +762,9 @@ void lxrc_init()
 
   config.mountpoint.instdata = strdup("/var/adm/mount");
 
-  config.setupcmd = strdup("setctsid `showconsole` inst_setup yast");
+  config.setupcmd = strdup("setsid -wc inst_setup yast");
 
-  config.debugshell = strdup("setctsid `showconsole` /bin/bash -l");
+  config.debugshell = strdup("setsid -wc /bin/bash -l");
 
   config.update.map = calloc(1, MAX_UPDATES);
 


### PR DESCRIPTION
setsid's '-c' option does the same as setctsid (set controlling terminal).