### PR TITLE
Added new BuildRequires to devel doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Compiling linuxrc will require some additional dependencies.
 
 For example on openSUSE/SUSE distributions run:
 ```sh
-zypper install e2fsprogs-devel hwinfo-devel libblkid-devel libcurl-devel readline-devel
+zypper install e2fsprogs-devel hwinfo-devel libblkid-devel libcurl-devel readline-devel libmediacheck-devel
 ```
 ## Debugging
 


### PR DESCRIPTION
linuxrc doesn't build without that package. It's there in the .spec file, but not in the instructions in the README.md.