### PR TITLE
Added parameter norepo (fate#325482)

### DIFF
--- a/file.c
+++ b/file.c
@@ -311,6 +311,7 @@ static struct {
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
   { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
   { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
+  { key_norepo,         "NoRepo",         kf_cfg + kf_cmd                },
 };
 
 static struct {
@@ -1766,6 +1767,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         str_copy(&config.core, *f->value ? f->value : NULL);
         break;
 
+      case key_norepo:
+        if(f->is.numeric) config.norepo = f->nvalue;
+        break;
+
       default:
         break;
     }
@@ -1883,7 +1888,7 @@ void file_write_install_inf(char *dir)
   file_write_num(f, key_sourcemounted, url->mount ? 1 : 0);
 
   fprintf(f, "RepoURL: %s\n", url_print(url, 3));
-  fprintf(f, "ZyppRepoURL: %s\n", url_print(url, 4));
+  if(!config.norepo)   fprintf(f, "ZyppRepoURL: %s\n", url_print(url, 4));
   if(!config.sslcerts) fprintf(f, "ssl_verify: no\n");
 
   if(url->used.device && !url->is.network) fprintf(f, "Device: %s\n", short_dev(url->used.device));

--- a/file.h
+++ b/file.h
@@ -56,7 +56,7 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core
+  key_ibft_devices, key_linuxrc_core, key_norepo
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -446,6 +446,7 @@ typedef struct {
   unsigned systemboot:1;	/**< boot installed system */
   unsigned extend_running:1;	/**< currently running an 'extend' job */
   unsigned repomd:1;		/**< install repo is repo-md */
+  unsigned norepo:1;            /**< disable repo location check, expect YaST */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */

--- a/util.c
+++ b/util.c
@@ -1204,6 +1204,7 @@ void util_status_info(int log_it)
   add_flag(&sl0, buf, config.net.sethostname, "hostname");
   add_flag(&sl0, buf, config.self_update, "self_update");
   add_flag(&sl0, buf, config.repomd, "repomd");
+  add_flag(&sl0, buf, config.norepo, "norepo");
   if(*buf) slist_append_str(&sl0, buf);
 
   if(config.self_update_url) {


### PR DESCRIPTION
Documentation:

https://en.opensuse.org/SDB:Linuxrc

> NoRepo
>
> Disable the repo location check and do not write a ZyppRepoURL to /etc/install.inf; expect YaST to take care of the repo selection.
>
> This is useful for delegating the repo selection to the registration server so a user can simply enter a registration code first, then the matching product will be automatically selected based on that registration code, and the respective repos will be addded accordingly (Fate#325482).
