### PR TITLE
fix network dialog workflow when VLAN is active (bsc #1124654)

### DIFF
--- a/net.c
+++ b/net.c
@@ -150,7 +150,7 @@ int net_config()
     if(rc) return -1;
   }
 
-  if(config.win && config.net.setup != NS_DHCP) {
+  if(config.win && (config.net.setup & ~NS_VLANID) != NS_DHCP) {
     if(
       config.net.setup & NS_DHCP &&
 #if defined(__s390__) || defined(__s390x__)

--- a/net.c
+++ b/net.c
@@ -150,6 +150,11 @@ int net_config()
     if(rc) return -1;
   }
 
+  /*
+   * VLANID is handled in net_input_vlanid() a few lines above. Take this
+   * into account when deciding if there's anything else besides DHCP to be
+   * done.
+   */
   if(config.win && (config.net.setup & ~NS_VLANID) != NS_DHCP) {
     if(
       config.net.setup & NS_DHCP &&

--- a/net.c
+++ b/net.c
@@ -1164,6 +1164,8 @@ void net_wicked_dhcp()
   if(config.test) {
     config.net.dhcp_active = 1;
 
+    log_info("test mode: DHCP activated\n");
+
     return;
   }
 
@@ -2592,7 +2594,12 @@ void net_wicked_up(char *ifname)
     strprintf(&buf, "wicked ifup %s", ifname);
   }
 
-  if(!config.test) lxrc_run(buf);
+  if(!config.test) {
+    lxrc_run(buf);
+  }
+  else {
+    log_info("test mode: 'wicked ifup %s' called\n", ifname);
+  }
 
   sleep(config.net.ifup_wait + 1);
 


### PR DESCRIPTION
## Problem

On s390, answering 'No' in the 'Do DHCP?' dialog leads not to the static setup dialog but to no network.

- bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1124654
- Scrum card: https://trello.com/c/bzchqEQA

## Solution

The issue was caused by an incorrect workflow when VLAN is used.

Note that the expected correct behavior here is **not** to ask for DHCP at all but to do it automatically.