### PR TITLE
add 'autoassembly' boot option to prevent MD/RAID autoassembly (bsc #1132688)

### DIFF
--- a/file.c
+++ b/file.c
@@ -312,6 +312,7 @@ static struct {
   { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
   { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
   { key_norepo,         "NoRepo",         kf_cfg + kf_cmd                },
+  { key_auto_assembly,  "AutoAssembly",   kf_cfg + kf_cmd_early          },
 };
 
 static struct {
@@ -1769,6 +1770,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_norepo:
         if(f->is.numeric) config.norepo = f->nvalue;
+        break;
+
+      case key_auto_assembly:
+        if(f->is.numeric) config.auto_assembly = f->nvalue;
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -56,7 +56,7 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core, key_norepo
+  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -447,6 +447,7 @@ typedef struct {
   unsigned extend_running:1;	/**< currently running an 'extend' job */
   unsigned repomd:1;		/**< install repo is repo-md */
   unsigned norepo:1;            /**< disable repo location check, expect YaST */
+  unsigned auto_assembly:1;	/**< enable MD/RAID auto-assembly */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -800,6 +800,7 @@ void lxrc_init()
   config.udev_mods = 1;
   config.devtmpfs = 1;
   config.kexec = 2;		/* kexec if necessary, with user dialog */
+  config.auto_assembly = 1;	/* default to allow MD/RAID auto-assembly for now (bsc#1132688) */
 
   // defaults for self-update feature
   config.self_update_url = NULL;

--- a/util.c
+++ b/util.c
@@ -4605,8 +4605,7 @@ void util_run_script(char *name)
 
   /* pass the negated setting to stay compatible */
   if(!config.auto_assembly) {
-    strprintf(&buf, "%d", !config.auto_assembly);
-    setenv("linuxrc_no_auto_assembly", buf, 1);
+    setenv("linuxrc_no_auto_assembly", "1", 1);
   }
 
   if(config.loghost) setenv("LOGHOST", config.loghost, 1);

--- a/util.c
+++ b/util.c
@@ -4573,6 +4573,21 @@ char *mac_to_interface(char *mac, int *max_offset)
 }
 
 
+/*
+ * Outsource some setup tasks to shell scripts.
+ *
+ * Several linuxrc config settings are passed as environment vars to the
+ * scripts:
+ *
+ *   config.loghost        -> $LOGHOST
+ *   !config.auto_assembly -> $linuxrc_no_auto_assembly
+ *   config.debug          -> $linuxrc_debug
+ *
+ * /etc/install.inf is available when the scripts run.
+ *
+ * Scripts can pass settings back to linuxrc by putting them into
+ * /tmp/script.result (ususal info-file syntax).
+ */
 void util_run_script(char *name)
 {
   char *buf = NULL;
@@ -4586,6 +4601,12 @@ void util_run_script(char *name)
   if(config.debug) {
     strprintf(&buf, "%d", config.debug);
     setenv("linuxrc_debug", buf, 1);
+  }
+
+  /* pass the negated setting to stay compatible */
+  if(!config.auto_assembly) {
+    strprintf(&buf, "%d", !config.auto_assembly);
+    setenv("linuxrc_no_auto_assembly", buf, 1);
   }
 
   if(config.loghost) setenv("LOGHOST", config.loghost, 1);


### PR DESCRIPTION
### Bug report

https://bugzilla.suse.com/show_bug.cgi?id=1132688

### Scrum board

https://trello.com/c/0S3qkpcj

### Solution

Introduce [`autoassembly`](https://en.opensuse.org/SDB:Linuxrc#p_autoassembly) boot option.
The default is 1 (enable). So unless `autoassembly=0` is explicitly given, nothing changes.

### Related

https://github.com/openSUSE/installation-images/pull/311