### PR TITLE
Backport: add 'autoassembly' boot option to prevent MD/RAID autoassembly (bsc #1132688)

### DIFF
--- a/file.c
+++ b/file.c
@@ -311,6 +311,7 @@ static struct {
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
   { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
   { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
+  { key_auto_assembly,  "AutoAssembly",   kf_cfg + kf_cmd_early          },
 };
 
 static struct {
@@ -1779,6 +1780,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_linuxrc_core:
         str_copy(&config.core, *f->value ? f->value : NULL);
+        break;
+
+      case key_auto_assembly:
+        if(f->is.numeric) config.auto_assembly = f->nvalue;
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -56,7 +56,7 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core
+  key_ibft_devices, key_linuxrc_core, key_auto_assembly
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -446,6 +446,7 @@ typedef struct {
   unsigned systemboot:1;	/**< boot installed system */
   unsigned extend_running:1;	/**< currently running an 'extend' job */
   unsigned repomd:1;		/**< install repo is repo-md */
+  unsigned auto_assembly:1;	/**< enable MD/RAID auto-assembly */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -800,6 +800,7 @@ void lxrc_init()
   config.udev_mods = 1;
   config.devtmpfs = 1;
   config.kexec = 2;		/* kexec if necessary, with user dialog */
+  config.auto_assembly = 1;	/* default to allow MD/RAID auto-assembly for now (bsc#1132688) */
 
   // defaults for self-update feature
   config.self_update_url = NULL;

--- a/util.c
+++ b/util.c
@@ -4599,8 +4599,7 @@ void util_run_script(char *name)
 
   /* pass the negated setting to stay compatible */
   if(!config.auto_assembly) {
-    strprintf(&buf, "%d", !config.auto_assembly);
-    setenv("linuxrc_no_auto_assembly", buf, 1);
+    setenv("linuxrc_no_auto_assembly", "1", 1);
   }
 
   if(config.loghost) setenv("LOGHOST", config.loghost, 1);

--- a/util.c
+++ b/util.c
@@ -4567,6 +4567,21 @@ char *mac_to_interface(char *mac, int *max_offset)
 }
 
 
+/*
+ * Outsource some setup tasks to shell scripts.
+ *
+ * Several linuxrc config settings are passed as environment vars to the
+ * scripts:
+ *
+ *   config.loghost        -> $LOGHOST
+ *   !config.auto_assembly -> $linuxrc_no_auto_assembly
+ *   config.debug          -> $linuxrc_debug
+ *
+ * /etc/install.inf is available when the scripts run.
+ *
+ * Scripts can pass settings back to linuxrc by putting them into
+ * /tmp/script.result (ususal info-file syntax).
+ */
 void util_run_script(char *name)
 {
   char *buf = NULL;
@@ -4580,6 +4595,12 @@ void util_run_script(char *name)
   if(config.debug) {
     strprintf(&buf, "%d", config.debug);
     setenv("linuxrc_debug", buf, 1);
+  }
+
+  /* pass the negated setting to stay compatible */
+  if(!config.auto_assembly) {
+    strprintf(&buf, "%d", !config.auto_assembly);
+    setenv("linuxrc_no_auto_assembly", buf, 1);
   }
 
   if(config.loghost) setenv("LOGHOST", config.loghost, 1);


### PR DESCRIPTION
_This is a backport of PR #188._

## Trello

https://trello.com/c/A1orfA6C/1135-2-sle12-sp5-p2-1138583-error-disk-remove-partition-failed-occurred-while-installing-on-multipath-setup

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1138583

## Original PR

https://github.com/openSUSE/linuxrc/pull/188

Cherry-picked both commits of that PR and fixed the conflicts (no "NoRepo" option in this branch).

