### PR TITLE
Disable MD/RAID auto-assembly by default (bsc#1132688)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -800,7 +800,7 @@ void lxrc_init()
   config.udev_mods = 1;
   config.devtmpfs = 1;
   config.kexec = 2;		/* kexec if necessary, with user dialog */
-  config.auto_assembly = 1;	/* default to allow MD/RAID auto-assembly for now (bsc#1132688) */
+  config.auto_assembly = 0;	/* default to disable MD/RAID auto-assembly (bsc#1132688) */
 
   // defaults for self-update feature
   config.self_update_url = NULL;


### PR DESCRIPTION
## Trello

https://trello.com/c/h92INIpW/1087-1-15-sp2-make-autoassembly0-the-default-setting-in-sle-15-sp2

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1132688

## Problem

Auto-assembly of RAIDs during installation happens at the most inconvenient times, often clashing with operations that libstorage-ng / yast-storage-ng are doing.

## Solution

Disable auto-assembly. Linuxrc now has a command line option for that; until now, auto-assembly was enabled by default. This commit changes that.