### PR TITLE
choose correct kernel image on aarch64 (bsc#1145625)

### DIFF
--- a/util.c
+++ b/util.c
@@ -4966,6 +4966,8 @@ slist_t *get_kernel_list(char *dev)
   char *kernel_pattern = "image-*";
 #elif defined(__x86_64__) || defined(__i386__)
   char *kernel_pattern = "vmlinuz-*";
+#elif defined(__aarch64__)
+  char *kernel_pattern = "Image-*";
 #else
   char *kernel_pattern = "vmlinux-*";
 #endif


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1145625

'Boot linux system' boot option does not work on aarch64.

## Analysis

When booting 'installed system' linuxrc has to pick the correct kernel/initrd pair. Unfortunately the kernel naming scheme differs for each architecture.

## See also

[Original fix in `master`](https://github.com/openSUSE/linuxrc/pull/193)