### PR TITLE
add support for compressed modules

### DIFF
--- a/global.h
+++ b/global.h
@@ -131,8 +131,6 @@ enum langid_t {
 
 #define MAX_FILENAME     300
 
-#define MODULE_SUFFIX	".ko"
-
 typedef struct {
                int c;
                char attr;

--- a/module.h
+++ b/module.h
@@ -21,3 +21,6 @@ void       mod_show_modules(void);
 void       mod_disk_text(char *buf, int type);
 int        mod_copy_modules(char *src_dir, int doit);
 int        mod_cmp(char *str1, char *str2);
+int        mod_has_module_ext(const char *file, const size_t len,
+		size_t *ext_pos);
+int        mod_find_module(const char *prefix, const char *module, char *file);

--- a/util.c
+++ b/util.c
@@ -730,7 +730,6 @@ int util_eject_cdrom(char *dev)
 void add_driver_update(char *dir, char *loc)
 {
   unsigned u;
-  size_t len;
   char *copy_dir[] = { "install", "modules", "y2update", "inst-sys" };
   char *src = NULL, *dst = NULL, *buf1 = NULL, *buf2 = NULL;
   char *argv[3];
@@ -844,10 +843,7 @@ void add_driver_update(char *dir, char *loc)
       strprintf(&buf2, "%s/modules/module.order", dst);
       if(!util_check_exist(buf2) && (f = fopen(buf2, "w"))) {
         while((de = readdir(d))) {
-          if(
-            (len = strlen(de->d_name)) > sizeof MODULE_SUFFIX - 1 &&
-            !strcmp(de->d_name + len - (sizeof MODULE_SUFFIX - 1), MODULE_SUFFIX)
-          ) {
+          if(mod_has_module_ext(de->d_name, strlen(de->d_name), NULL)) {
             fprintf(f, "%s\n", de->d_name);
           }
         }


### PR DESCRIPTION
We enabled compressed modules in 5.3. We added support into
installation-images, but forgot to add the support to linuxrc. So do it
now.

This removes the global hardcoded MODULE_SUFFIX and introduces a list of
possible module extensions instead. New functions mod_has_module_ext and
mod_find_module are introduced to cover the functionality. It also
cleans up the code significantly.

config.forceinsmod works differently in mod_insmod now. We have to check
the path as we have to find whether the module is compressed or not. But
I think it makes little sense not to do so. Looking at b1033964884a, I
cannot see why the check is skipped when force-loading?