### PR TITLE
support autoyast url schemes in linuxrc

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -911,10 +911,7 @@ void auto2_read_repo_files(url_t *url)
       log_info("setting AutoYaST option to file:/autoinst.xml\n");
       url_free(config.url.autoyast);
       config.url.autoyast = url_set("file:/autoinst.xml");
-      /* parse it:
-       * you can embed linuxrc options between lines with '# {start,end}_linuxrc_conf';
-       * otherwise the file content is ignored
-       */
+      // parse for embedded linuxrc options in <info_file> element
       log_info("parsing AutoYaST file\n");
       file_read_info_file("file:/autoinst.xml", kf_cfg);
       net_update_ifcfg(IFCFG_IFUP);
@@ -1283,10 +1280,7 @@ void auto2_read_autoyast(url_t *url)
   url_umount(url);
 
   if(!err) {
-    /* parse it:
-     * you can embed linuxrc options between lines with '# {start,end}_linuxrc_conf';
-     * otherwise the file content is ignored
-     */
+    // parse for embedded linuxrc options in <info_file> element
     log_info("parsing AutoYaST file\n");
     file_read_info_file("file:/download/autoinst.xml", kf_cfg);
     net_update_ifcfg(IFCFG_IFUP);

--- a/auto2.c
+++ b/auto2.c
@@ -36,11 +36,13 @@
 
 static int driver_is_active(hd_t *hd);
 static void auto2_progress(char *pos, char *msg);
+static void auto2_read_repo_file(url_t *url, char *src, char *dst);
 static void auto2_read_repo_files(url_t *url);
 static void auto2_read_repomd_files(url_t *url);
 static char *auto2_splash_name(void);
 
 static int test_and_add_dud(url_t *url);
+static void auto2_read_autoyast(url_t *url);
 
 
 /*
@@ -364,31 +366,9 @@ void auto2_scan_hardware()
   }
 
   /*
-   * load autoyast file unless the user has specified an autoyast option
-   * -- ok this sounds weird but actually makes sense...
+   * load autoyast file; prefer autoyast option over autoyast2
    */
-  if(config.autoyast2 && !config.autoyast) {
-    url = url_set(config.autoyast2);
-    log_show_maybe(!url->quiet, "Downloading AutoYaST file: %s\n", config.autoyast2);
-
-    err = url_read_file_anywhere(url, NULL, NULL, "/download/autoinst.xml", NULL, URL_FLAG_PROGRESS + URL_FLAG_NODIGEST);
-    url_umount(url);
-    url_free(url);
-    if(!err) {
-      log_info("setting AutoYaST option to file:///download/autoinst.xml\n");
-      str_copy(&config.autoyast, "file:///download/autoinst.xml");
-      /* parse it:
-       * you can embed linuxrc options between lines with '# {start,end}_linuxrc_conf';
-       * otherwise the file content is ignored
-       */
-      log_info("parsing AutoYaST file\n");
-      file_read_info_file("file:/download/autoinst.xml", kf_cfg);
-      net_update_ifcfg(IFCFG_IFUP);
-    }
-    else {
-      log_show_maybe(!url->quiet, "Failed to download AutoYaST file.\n");
-    }
-  }
+  auto2_read_autoyast(config.url.autoyast && config.autoyast_parse ? config.url.autoyast : config.url.autoyast2);
 
   /* load & run driverupdates */
   if(config.update.urls) {
@@ -863,6 +843,28 @@ char *auto2_serial_console()
   return console;
 }
 
+/*
+ * Read a single file from repo directory.
+ *
+ * Be careful not to replace an existing file unless we successfully got
+ * a new version.
+ */
+void auto2_read_repo_file(url_t *url, char *src, char *dst)
+{
+  char *tmp_file = NULL;
+
+  str_copy(&tmp_file, new_download());
+  if(
+    !url_read_file(url, NULL, src, tmp_file, NULL, URL_FLAG_NODIGEST + URL_FLAG_OPTIONAL) &&
+    util_check_exist(tmp_file)
+  ) {
+    rename(tmp_file, dst);
+    log_info("mv %s -> %s\n", tmp_file, dst);
+  }
+
+  str_copy(&tmp_file, NULL);
+}
+
 
 /*
  * Get various files from repositrory for yast's convenience.
@@ -870,9 +872,7 @@ char *auto2_serial_console()
 void auto2_read_repo_files(url_t *url)
 {
   int i;
-  char *tmp_file = NULL;
   static char *default_list[][2] = {
-    { "/autoinst.xml", "/tmp/autoinst.xml" },
     { "/control.xml", "/control.xml" },
     { "/license.tar.gz", "/license.tar.gz" },
     { "/media.1/info.txt", "/info.txt" },
@@ -881,25 +881,36 @@ void auto2_read_repo_files(url_t *url)
   };
 
   for(i = 0; i < sizeof default_list / sizeof *default_list; i++) {
-    // be careful not to replace an existing file unless we successfully got
-    // a new version
-    str_copy(&tmp_file, new_download());
-    if(
-      !url_read_file(url, NULL, default_list[i][0], tmp_file, NULL, URL_FLAG_NODIGEST + URL_FLAG_OPTIONAL) &&
-      util_check_exist(tmp_file)
-    ) {
-      rename(tmp_file, default_list[i][1]);
-      log_info("mv %s -> %s\n", tmp_file, default_list[i][1]);
-    }
+    auto2_read_repo_file(url, default_list[i][0], default_list[i][1]);
   }
 
-  str_copy(&tmp_file, NULL);
+  char *autoyast_file = NULL;
 
-  if(!config.autoyast) {
+  if(config.url.autoyast) {
+    if(
+      config.url.autoyast->scheme == inst_rel &&
+      config.autoyast_parse
+    ) {
+      log_show_maybe(!config.url.autoyast->quiet, "AutoYaST file in repo: %s\n", url_print(config.url.autoyast, 5));
+
+      if(!config.url.autoyast->is.dir) {
+        autoyast_file = config.url.autoyast->path;
+      }
+    }
+  }
+  else {
+    autoyast_file = "/autoinst.xml";
+  }
+
+  if(autoyast_file) {
+    auto2_read_repo_file(url, autoyast_file, "/tmp/autoinst.xml");
+
     if(util_check_exist("/tmp/autoinst.xml")) rename("/tmp/autoinst.xml", "/autoinst.xml");
+
     if(util_check_exist("/autoinst.xml")) {
-      log_info("setting AutoYaST option to file:///autoinst.xml\n");
-      str_copy(&config.autoyast, "file:///autoinst.xml");
+      log_info("setting AutoYaST option to file:/autoinst.xml\n");
+      url_free(config.url.autoyast);
+      config.url.autoyast = url_set("file:/autoinst.xml");
       /* parse it:
        * you can embed linuxrc options between lines with '# {start,end}_linuxrc_conf';
        * otherwise the file content is ignored
@@ -920,31 +931,18 @@ void auto2_read_repo_files(url_t *url)
 void auto2_read_repomd_files(url_t *url)
 {
   int i;
-  char *tmp_file = NULL;
   static char *default_list[][2] = {
     { "license", "/license.tar.gz" },
     { "/README.BETA", "/README.BETA" }
   };
 
   for(i = 0; i < sizeof default_list / sizeof *default_list; i++) {
-    // be careful not to replace an existing file unless we successfully got
-    // a new version
-
     // get real file name
     slist_t *sl = slist_getentry(config.repomd_data, default_list[i][0]);
     if(!sl) continue;
 
-    str_copy(&tmp_file, new_download());
-    if(
-      !url_read_file(url, NULL, sl->value, tmp_file, NULL, URL_FLAG_NODIGEST) &&
-      util_check_exist(tmp_file)
-    ) {
-      rename(tmp_file, default_list[i][1]);
-      log_info("mv %s -> %s\n", tmp_file, default_list[i][1]);
-    }
+    auto2_read_repo_file(url, sl->value, default_list[i][1]);
   }
-
-  str_copy(&tmp_file, NULL);
 }
 
 
@@ -1242,3 +1240,58 @@ int auto2_remove_extension(char *extension)
   return err;
 }
 
+
+/*
+ * Read autoyast file from url and parse it.
+ *
+ * If the autoyast url points to a directory, nothing is read but the
+ * function tries to mount the directory to ensure it exists. This is
+ * basically done to search for the correct medium.
+ */
+void auto2_read_autoyast(url_t *url)
+{
+  if(!url) return;
+
+  // rel url is taken care of in auto2_read_repo_files()
+  if(url->scheme == inst_rel) return;
+
+  /*
+   * If the AutoYaST url is a directory we have to very its existence
+   * somehow.
+   *
+   * That works for mountable url schemes.
+   *
+   * For the rest (http(s), (t)ftp) we'll just assume it works.
+   */
+  if(url->is.dir) {
+    /*
+     * do nothing but
+     *   - ensure network is set up
+     *   - the correct disk device has been identified
+     */
+    if(url->is.mountable) {
+      url_mount(url, NULL, NULL);
+      url_umount(url);
+    }
+
+    return;
+  }
+
+  log_show_maybe(!url->quiet, "Downloading AutoYaST file: %s\n", url->str);
+
+  int err = url_read_file_anywhere(url, NULL, NULL, "/download/autoinst.xml", NULL, URL_FLAG_PROGRESS + URL_FLAG_NODIGEST);
+  url_umount(url);
+
+  if(!err) {
+    /* parse it:
+     * you can embed linuxrc options between lines with '# {start,end}_linuxrc_conf';
+     * otherwise the file content is ignored
+     */
+    log_info("parsing AutoYaST file\n");
+    file_read_info_file("file:/download/autoinst.xml", kf_cfg);
+    net_update_ifcfg(IFCFG_IFUP);
+  }
+  else {
+    log_show_maybe(!url->quiet, "Failed to download AutoYaST file.\n");
+  }
+}

--- a/file.c
+++ b/file.c
@@ -1087,11 +1087,20 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         }
         slist_free(sl0);
 
+        config.log.dest[1].level =
+          config.debug ? LOG_LEVEL_SHOW | LOG_LEVEL_INFO | LOG_LEVEL_DEBUG | LOG_TIMESTAMP : LOG_LEVEL_INFO;
+
         if(config.error_trace) {
           config.log.dest[2].level |= LOG_CALLER;
+          if(config.debug) {
+            config.log.dest[1].level |= LOG_CALLER;
+          }
         }
         else {
           config.log.dest[2].level &= ~LOG_CALLER;
+          if(config.debug) {
+            config.log.dest[1].level &= ~LOG_CALLER;
+          }
         }
         break;
 

--- a/file.c
+++ b/file.c
@@ -117,6 +117,9 @@ static struct {
   { key_screenmap,      "Screenmap",      kf_none                        },
   { key_fontmagic,      "Fontmagic",      kf_none                        },
   { key_autoyast,       "AutoYaST",       kf_cfg + kf_cmd_early          },
+  { key_autoyast,       "AY",             kf_cfg + kf_cmd_early          },
+  { key_autoyast_parse, "AutoYaSTParse",  kf_cfg + kf_cmd_early          },
+  { key_autoyast_parse, "AYParse",        kf_cfg + kf_cmd_early          },
   { key_autoyast2,      "AutoYaST2",      kf_cfg + kf_cmd_early          },
   { key_linuxrc,        "linuxrc",        kf_cfg + kf_cmd_early          },
   { key_forceinsmod,    "ForceInsmod",    kf_cfg + kf_cmd                },
@@ -350,11 +353,16 @@ static struct {
   { "exec",      inst_exec          },
   { "rel",       inst_rel           },
   { "disk",      inst_disk          },
-  { "extern",    inst_extern        },
+  { "usb",       inst_usb           },
+  { "label",     inst_label         },
   /* add new inst modes _here_! */
+  { "extern",    inst_extern        },
+  /* the following are just aliases */
   { "harddisk",  inst_hd            },
   { "cdrom",     inst_cdrom         },
   { "cifs",      inst_smb           },
+  { "device",    inst_disk          },
+  { "relurl",    inst_rel           },
 #if defined(__s390__) || defined(__s390x__)
   { "osa",	 di_390net_osa      },
   { "ctc",	 di_390net_ctc	    },
@@ -843,12 +851,24 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         break;
 
       case key_autoyast:
-        str_copy(&config.autoyast, *f->value ? f->value : "default");
+        config.url.autoyast = url_free(config.url.autoyast);
+        if(strcmp(f->value, "default")) {
+          config.url.autoyast = url_set(f->value);
+          // if it's an SLP url, add 'autoyast' service query per default
+          if(config.url.autoyast->scheme == inst_slp) {
+            slist_setentry(&config.url.autoyast->query, "service", "autoyast", 0);
+          }
+        }
         config.manual = 0;
         break;
 
       case key_autoyast2:
-        str_copy(&config.autoyast2, *f->value ? f->value : NULL);
+        url_free(config.url.autoyast2);
+        config.url.autoyast2 = url_set(f->value);
+        break;
+
+      case key_autoyast_parse:
+        if(f->is.numeric) config.autoyast_parse = f->nvalue;
         break;
 
       case key_info:
@@ -1928,13 +1948,18 @@ void file_write_install_inf(char *dir)
   file_write_str(f, key_updatedir, config.update.dir);
   file_write_num(f, key_yast2update, config.update.ask || config.update.count ? 1 : 0);
   file_write_num(f, key_textmode, config.textmode);
-  file_write_str(f, key_autoyast, config.autoyast);
+  if(config.url.autoyast) {
+    log_info("final autoyast url: %s\n", url_print(config.url.autoyast, 0));
+    file_write_str(f, key_autoyast,
+      config.autoyast_parse ? url_print(config.url.autoyast, 5) : config.url.autoyast->str
+    );
+  }
   /*
    * autoyast + upgrade = autoupgrade
    *
    * autoyast uses a different config var to trigger updates for historical reasons
    */
-  if(config.autoyast && config.upgrade) {
+  if(config.url.autoyast && config.upgrade) {
     fprintf(f, "AutoUpgrade: 1\n");
   }
   file_write_num(f, key_memfree, config.memoryXXX.current >> 10);	// convention: in kB

--- a/file.c
+++ b/file.c
@@ -635,20 +635,29 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
   unsigned u;
   FILE *w;
 
-  /* maybe it's an AutoYaST XML file */
+  /*
+   * Maybe it's an AutoYaST XML file.
+   *
+   * If so, try limiting the scope to lines in first '<info_file>' element.
+   */
   for(f = f0; f; f = f->next) {
-    if(f->key == key_comment && !strcmp(f->value, "start_linuxrc_conf")) {
-      is_xml = 1;
-      f0 = f->next;
-      break;
+    if(f->key == key_none) {
+      if(!strncmp(f->key_str, "<info_file", sizeof "<info_file" - 1)) {
+        is_xml = 1;
+        f0 = f->next;
+        break;
+      }
+      if(!strcmp(f->key_str, "</profile>")) {
+        is_xml = 1;
+      }
     }
   }
 
   for(f = f0; f; f = f->next) {
     if(
       is_xml &&
-      f->key == key_comment &&
-      !strcmp(f->value, "end_linuxrc_conf")
+      f->key == key_none &&
+      !strcmp(f->key_str, "</info_file>")
     ) {
       break;
     }

--- a/file.h
+++ b/file.h
@@ -56,7 +56,7 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly
+  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -185,7 +185,7 @@ typedef enum {
   inst_none = 0, inst_file, inst_nfs, inst_ftp, inst_smb,
   inst_http, inst_https, inst_tftp, inst_cdrom, inst_floppy, inst_hd,
   inst_dvd, inst_cdwithnet, inst_net, inst_slp, inst_exec,
-  inst_rel, inst_disk,
+  inst_rel, inst_disk, inst_usb, inst_label,
   inst_extern ///< must be last
 } instmode_t;
 
@@ -265,6 +265,7 @@ typedef enum {
 typedef struct {
   char *str;
   instmode_t scheme;
+  instmode_t orig_scheme;
   char *server;
   char *share;
   char *path;
@@ -287,6 +288,7 @@ typedef struct {
     unsigned mountable:1;	/**< scheme is mountable */
     unsigned cdrom:1;		/**< device is cdrom */
     unsigned file:1;		/**< path points to file (not to directory) */
+    unsigned dir:1;		/**< path points to directory (not to file ) */
     unsigned wlan:1;		/**< wlan interface */
     unsigned blockdev:1;	/**< needs block device */
     unsigned nodevneeded:1;	/**< does not need any device */
@@ -446,6 +448,7 @@ typedef struct {
   unsigned repomd:1;		/**< install repo is repo-md */
   unsigned norepo:1;            /**< disable repo location check, expect YaST */
   unsigned auto_assembly:1;	/**< enable MD/RAID auto-assembly */
+  unsigned autoyast_parse:1;	/**< analyse autoyast parameter */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */
@@ -465,8 +468,6 @@ typedef struct {
     slist_t *file;		/**< 'info' file name */
     unsigned add_cmdline:1;	/**< parse cmdline, too */
   } info;
-  char *autoyast;		/**< yast autoinstall parameter */
-  char *autoyast2;		/**< yast autoinstall parameter, loaded by linuxrc */
   char *yepurl;			/**< just pass it to yast */
   char *supporturl;		/**< just pass it to yast */
   slist_t *linuxrc;		/**< 'linuxrc' parameters */
@@ -540,6 +541,8 @@ typedef struct {
     url_t *install;		/**< install url */
     url_t *instsys;		/**< instsys url */
     url_t *proxy;		/**< proxy url */
+    url_t *autoyast;		/**< yast autoinstall parameter */
+    url_t *autoyast2;		/**< alternative yast autoinstall parameter */
   } url;
 
   struct {			/**< libblkid related things */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -801,6 +801,7 @@ void lxrc_init()
   config.devtmpfs = 1;
   config.kexec = 2;		/* kexec if necessary, with user dialog */
   config.auto_assembly = 0;	/* default to disable MD/RAID auto-assembly (bsc#1132688) */
+  config.autoyast_parse = 1;	/* analyse autoyast option and read autoyast file */
 
   // defaults for self-update feature
   config.self_update_url = NULL;

--- a/linuxrc_and_autoyast.md
+++ b/linuxrc_and_autoyast.md
@@ -1,0 +1,72 @@
+# AutoYaST handling in linuxrc
+
+## Why?
+
+AutoYaST is something very specific to YaST and linuxrc has nothing to do
+with it. So why would it have to deal with it at all?
+
+In fact, linuxrc did ignore the `autoyast` boot option for a long time and
+just passed it on via `/etc/install.inf` to yast.
+
+There are several reasons why linuxrc has to get involved:
+
+1. You can embed linuxrc options into the AutoYaST config
+  https://doc.opensuse.org/projects/autoyast/#invoking_autoinst.linuxrc.
+
+2. An AutoYaST config is searched for and auto-loaded from a disk with label `OEMDRV`.
+
+3. There is the expectation that using `autoyast=ftp://foo/bar` causes linuxrc
+  to implicitly set up the network; much like `install=URL` or`dud=URL` does.
+
+For 3. to work linuxrc has to download the AutoYaST file to be sure the
+network setup has been done correctly.
+
+For 2. (and partly 1.) there had been the `autoyast2` option. But that was
+limited to linuxrc-style URLs and did not make any attempt to deal with
+AutoYaST rules.
+
+The main obstacles so far to get it right were:
+
+- AutoYaST has its own idiosyncratic set of URL schemes
+- it's not obvious which file should actually be loaded when AutoYaST rules come into play
+
+## Implementation
+
+1. linuxrc supports all AutoYaST URL schemes (see [References](#references) below); this
+implies you can also use AutoYaST-style URLs in other places in linuxrc
+2. linuxrc downloads the AutoYaST config file and parses it for linuxrc options - unless it's
+a rules-based setup
+3. linuxrc converts the URL used with the `autoyast` option into the canonical AutoYaST format and
+passes this on via `/etc/install.inf`; this means you can use both linuxrc-style ot AutoYaST-style URLs
+in linuxrc
+4. if the AutoYaST URL ends with a `/` (pointing to a directory) linuxrc
+assumes this to be a rules-based setup; for URLs with a mountable scheme,
+linuxrc goes looking for the specified directory; for all other URL schemes
+linuxrc does nothing and simply passes the URL on to YaST
+5. for URL schemes `usb` and `label` linuxrc identifies the device and converts the URL to a `device` scheme
+to ensure AutoYaST reads the same config; but if linuxrc could not find the AutoYaST file at
+the specified location, the original URL is passed
+6. for the `slp` scheme, linuxrc does the URL query and offers the user a
+selection dialog; the selected URL is then passed on to YaST; this makes the
+`slp` scheme work as documented (with `descr=XXX` query parameter) - which
+so far did not work
+7. as this is a major change and issues are likely to show up, there is a boot option to get back
+the old behavior: `autoyast.parse=0` - with this the `autoyast` option is left alone and just passed
+on to YaST
+8. the `autoyast2` option still exists for compatibility; it is ignored when `autoyast` is used
+9. there's a short alias `ay` for the `autoyast` option
+
+## References
+
+AutoYaST URL scheme doc
+
+- https://doc.opensuse.org/projects/autoyast/#Commandline.ay
+
+Understanding AutoYaST rules handling
+
+- https://doc.opensuse.org/projects/autoyast/#handlingrules
+
+Implementation of AutoYaST config file reading in YaST
+
+- https://github.com/yast/yast-installation/blob/master/src/lib/transfer/file_from_url.rb
+- https://github.com/yast/yast-autoinstallation/blob/master/src/modules/AutoinstConfig.rb

--- a/linuxrc_and_autoyast.md
+++ b/linuxrc_and_autoyast.md
@@ -13,9 +13,9 @@ There are several reasons why linuxrc has to get involved:
 1. You can embed linuxrc options into the AutoYaST config
   https://doc.opensuse.org/projects/autoyast/#invoking_autoinst.linuxrc.
 
-2. An AutoYaST config is searched for and auto-loaded from a disk with label `OEMDRV`.
+2. An AutoYaST config file `/autoinst.xml` is searched for and auto-loaded from a disk with label `OEMDRV`.
 
-3. There is the expectation that using `autoyast=ftp://foo/bar` causes linuxrc
+3. There is the expectation that using `autoyast=ftp://foo/bar` (or any network URL)  causes linuxrc
   to implicitly set up the network; much like `install=URL` or`dud=URL` does.
 
 For 3. to work linuxrc has to download the AutoYaST file to be sure the
@@ -37,7 +37,7 @@ implies you can also use AutoYaST-style URLs in other places in linuxrc
 2. linuxrc downloads the AutoYaST config file and parses it for linuxrc options - unless it's
 a rules-based setup
 3. linuxrc converts the URL used with the `autoyast` option into the canonical AutoYaST format and
-passes this on via `/etc/install.inf`; this means you can use both linuxrc-style ot AutoYaST-style URLs
+passes this on via `/etc/install.inf`; this means you can use both linuxrc-style and AutoYaST-style URLs
 in linuxrc
 4. if the AutoYaST URL ends with a `/` (pointing to a directory) linuxrc
 assumes this to be a rules-based setup; for URLs with a mountable scheme,
@@ -50,11 +50,17 @@ the specified location, the original URL is passed
 selection dialog; the selected URL is then passed on to YaST; this makes the
 `slp` scheme work as documented (with `descr=XXX` query parameter) - which
 so far did not work
-7. as this is a major change and issues are likely to show up, there is a boot option to get back
+7. linuxrc implicitly looks for an AutoYaST config file `autoinst.xml` in the repository directory; the
+file is downloaded as `/autoinst.xml` and a link to it passed on to YaST (using a `file` URL)
+8. there is not really an `autoyast=default` option; if this option is used, it just clears any previous
+autoyast setting; the reason is that `autoyast=default` is the default - linuxrc **always** looks for
+an AutoYaST config in the repository as described in 7.; see also
+https://en.opensuse.org/SDB:Linuxrc#AutoYaST_Profile_Handling
+9. as this is a major change and issues are likely to show up, there is a boot option to get back
 the old behavior: `autoyast.parse=0` - with this the `autoyast` option is left alone and just passed
 on to YaST
-8. the `autoyast2` option still exists for compatibility; it is ignored when `autoyast` is used
-9. there's a short alias `ay` for the `autoyast` option
+10. the `autoyast2` option still exists for compatibility; it is ignored when `autoyast` is used
+11. there's a short alias `ay` for the `autoyast` option
 
 ## References
 

--- a/slp.c
+++ b/slp.c
@@ -112,8 +112,8 @@ slp_get_descr(struct sockaddr_in *peer, unsigned char *url, int urllen)
   int s, l, l2, l3;
   int xid, al;
   char *d;
-  unsigned char sendbuf[8000];
-  unsigned char recvbuf[8000];
+  unsigned char sendbuf[0x10000];
+  unsigned char recvbuf[0x10000];
   unsigned char *bp, *end;
 
   xid = nextxid;
@@ -184,8 +184,8 @@ slp_get_descr(struct sockaddr_in *peer, unsigned char *url, int urllen)
 
 char *slp_get_install(url_t *url)
 {
-  unsigned char sendbuf[8000];
-  unsigned char recvbuf[80000];
+  unsigned char sendbuf[0x100000];
+  unsigned char recvbuf[0x100000];
   unsigned char *bp, *end, *service, service_key[256];
   int xid, l, s, l2, l3, ec, comma, ulen, i, acnt, service_key_len;
   struct sockaddr_in mysa;

--- a/util.c
+++ b/util.c
@@ -1247,8 +1247,15 @@ void util_status_info(int log_it)
     slist_append_str(&sl0, buf);
   }
 
-  if(config.autoyast) {
-    sprintf(buf, "autoyast = %s", config.autoyast);
+  if((s = url_print(config.url.autoyast, 0))) {
+    slist_append_str(&sl0, "autoyast url:");
+    sprintf(buf, "  %s", s);
+    slist_append_str(&sl0, buf);
+  }
+
+  if((s = url_print(config.url.autoyast2, 0))) {
+    slist_append_str(&sl0, "autoyast2 url:");
+    sprintf(buf, "  %s", s);
     slist_append_str(&sl0, buf);
   }
 


### PR DESCRIPTION
## Problem

Scrum card: https://trello.com/c/7tgF4mpl

## Solution

Support AutoYaST url schemes in linuxrc and evaluate the `autoyast` boot option in linuxrc.

Look at the details in 
https://github.com/openSUSE/linuxrc/blob/0830145d6740e437bd5b5681a38dfddb8eac1801/linuxrc_and_autoyast.md

## See also

* autoyast url scheme doc
 *   - https://doc.opensuse.org/projects/autoyast/#Commandline.ay
 *
 * actual implementation
 *   - https://github.com/yast/yast-installation/blob/master/src/lib/transfer/file_from_url.rb
 *   - https://github.com/yast/yast-autoinstallation/blob/master/src/modules/AutoinstConfig.rb