### PR TITLE
Add linuxrc reboot_timeout option

### DIFF
--- a/file.c
+++ b/file.c
@@ -149,6 +149,7 @@ static struct {
   { key_dhcptimeout,    "DHCPTimeout",    kf_cfg + kf_cmd_early          },
   { key_dhcptimeout,    "WickedTimeout",  kf_cfg + kf_cmd_early          },
   { key_tftptimeout,    "TFTPTimeout",    kf_cfg + kf_cmd                },
+  { key_reboot_timeout, "reboot_timeout", kf_cfg + kf_cmd                },
   { key_tmpfs,          "_TmpFS",         kf_cmd                         },
   { key_netstop,        "NetStop",        kf_cfg + kf_cmd                },
   { key_testmode,       "_TestMode",      kf_cfg                         },
@@ -738,6 +739,9 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
           config.net.dhcp_timeout = f->nvalue;
           config.net.dhcp_timeout_set = 1;
         }
+        break;
+      case key_reboot_timeout:
+        if(f->is.numeric) config.reboot_timeout = f->nvalue;
         break;
 
       case key_tftptimeout:
@@ -1953,6 +1957,7 @@ void file_write_install_inf(char *dir)
 
   file_write_str(f, key_loghost, config.loghost);
   if(config.restart_method) file_write_num(f, key_reboot, config.restart_method);
+  if(config.reboot_timeout >= 0) file_write_num(f, key_reboot_timeout, config.reboot_timeout);
   file_write_num(f, key_keyboard, 1);	/* we always have one - what's the point ??? */
   file_write_str(f, key_updatedir, config.update.dir);
   file_write_num(f, key_yast2update, config.update.ask || config.update.count ? 1 : 0);

--- a/file.h
+++ b/file.h
@@ -21,7 +21,7 @@ typedef enum {
   key_bootfile, key_install, key_instsys, key_instmode, key_memtotal,
   key_memfree, key_buffers, key_cached, key_swaptotal, key_swapfree,
   key_memlimit, key_memyast, key_memloadimage, key_info, key_proxy,
-  key_usedhcp, key_dhcptimeout, key_tftptimeout, key_tmpfs,
+  key_usedhcp, key_dhcptimeout, key_tftptimeout, key_reboot_timeout, key_tmpfs,
   key_testmode, key_debugwait, key_expert, key_rescue, key_rootimage,
   key_rescueimage, key_vnc, key_vncpassword, key_displayip,
   key_sshpassword, key_sshpasswordenc, key_term, key_addswap, key_aborted, key_netstop,

--- a/global.h
+++ b/global.h
@@ -431,6 +431,7 @@ typedef struct {
   unsigned restart_method;	/**< 0: start new root fs, 1: reboot, 2: halt, 3: kexec */
   unsigned efi_vars:1;		/**< efi vars exist */
   int efi;			/**< use efi; -1 = auto */
+  int reboot_timeout;		/**< reboot_timeout; -1: not_set, 0: disable, */
   unsigned udev_mods:1;		/**< let udev load modules */
   unsigned error_trace:1;	/**< enable backtrace log */
   unsigned early_bash:1;	/**< start bash on tty8 */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -802,6 +802,7 @@ void lxrc_init()
   config.kexec = 2;		/* kexec if necessary, with user dialog */
   config.auto_assembly = 0;	/* default to disable MD/RAID auto-assembly (bsc#1132688) */
   config.autoyast_parse = 1;	/* analyse autoyast option and read autoyast file */
+  config.reboot_timeout = -1; /* timeout seconds (use -1 as not set) */
 
   // defaults for self-update feature
   config.self_update_url = NULL;

--- a/linuxrc_yast_interface.txt
+++ b/linuxrc_yast_interface.txt
@@ -172,6 +172,10 @@ Options: %s
 # - obsolete - (technically impossible to actually see this entry)
 Reboot: Reboot|Halt|kexec
 
+# 0: Disable the countdown needing user confirmation to reboot the system
+# Timeout that YaST will wait until reboot the system (default: -1)
+reboot_timeout: %d
+
 # set via 'loghost' boot option
 # entry is missing if unset
 # - this is unused by linuxrc and just passed on -


### PR DESCRIPTION
@okurz is adding some patches in order to set the reboot timeout through linuxrc

See https://bugzilla.suse.com/show_bug.cgi?id=1122493

This PR is just for helping him with the changes needed.

See: https://github.com/yast/yast-yast2/pull/977 & https://github.com/yast/yast-installation/pull/823