### PR TITLE
ensure autoyast url is passed to yast when autoyast2 option is used (bsc #1157031)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -1280,6 +1280,10 @@ void auto2_read_autoyast(url_t *url)
   url_umount(url);
 
   if(!err) {
+    if(!config.url.autoyast) {
+      // this means 'autoyast2' has been used; point autoyast url to downloaded file
+      config.url.autoyast = url_set("file:/download/autoinst.xml");
+    }
     // parse for embedded linuxrc options in <info_file> element
     log_info("parsing AutoYaST file\n");
     file_read_info_file("file:/download/autoinst.xml", kf_cfg);


### PR DESCRIPTION
## Problem

When using the `autoyast2` option, no `AutoYaST` entry in `install.inf` is created.

- https://bugzilla.suse.com/show_bug.cgi?id=1157031

## Solution

This patch restores the old autoyast2 behavior: download the file (no rules and classes) and pass the downloaded file to yast. The 2nd step was missing.