### PR TITLE
fix 'label' URL scheme parsing

### DIFF
--- a/url.c
+++ b/url.c
@@ -798,6 +798,7 @@ void fixup_url_label(url_t *url)
     slist_t *sl = slist_setentry(&url->query, "device", NULL, 1);
     strprintf(&sl->value, "disk/by-label/%s", url->server);
     slist_setentry(&url->query, "label", url->server, 1);
+    str_copy(&url->server, NULL);
   }
   else if(url->path) {
     char *s = url->path;


### PR DESCRIPTION
## Problem

While testing fix https://github.com/openSUSE/linuxrc/pull/199 for https://bugzilla.suse.com/show_bug.cgi?id=1156967 an issue with the `label` URL scheme was uncovered.

`autoyast=label://label_foo/bar.xml` does not work.

## Solution

Fix parser (`server` var was not reset after use).