### PR TITLE
Added logic to linuxrc.c and util.c to retrieve the name of the proce…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 CC	= gcc
 CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
+ARCH	= $(shell /usr/bin/uname -m)
+ifeq ($(ARCH),s390x)
+LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck -lqc
+else
 LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
+endif
 
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
 GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 CC	= gcc
 CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
 ARCH	= $(shell /usr/bin/uname -m)
-ifeq ($(ARCH),s390x)
-LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck -lqc
-else
 LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
+ifeq ($(ARCH),s390x)
+LDFLAGS	+= -lqc
 endif
 
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)

--- a/global.h
+++ b/global.h
@@ -730,6 +730,7 @@ typedef struct {
     int portno;
     char* osahwaddr;
     char* hypervisor;
+    char machine_name[255];
   } hwp;
   
 #endif

--- a/global.h
+++ b/global.h
@@ -527,6 +527,7 @@ typedef struct {
                                  * 2: if necessary, with user dialog (default)
                                  * 3: if necessary, no user dialog
                                  */
+  char *platform_name;           /* Human-readable name of the hardware */
 
   struct {
     unsigned failed:1;		/**< digest check failed */
@@ -730,7 +731,6 @@ typedef struct {
     int portno;
     char* osahwaddr;
     char* hypervisor;
-    char machine_name[255];
   } hwp;
   
 #endif

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -759,11 +759,13 @@ void lxrc_init()
 
   if (qc_get_return_code<=0) {
     log_show("Unable to retrieve machine type.\n");
-    strncpy(config.hwp.machine_name, "unknown machine type", sizeof("unknown machine type")-1);
+    strprintf(&config.platform_name, "%s", "on unknown machine type");
   }
-  else strncpy(config.hwp.machine_name, qc_result_string, 254);
+  else strprintf(&config.platform_name, "on %s", qc_result_string);
 
   qc_close(qc_configuration_handle);
+  #else
+  config.platform_name="";
   #endif
 
   /* add cmdline to info file */
@@ -917,18 +919,11 @@ void lxrc_init()
   if(!config.had_segv) {
     if (config.linemode)
       putchar('\n');
-#ifdef __s390x__
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2019 SUSE LLC on %s <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2019 SUSE LLC %s <<<\n",
       config.product,
-      config.hwp.machine_name
+      config.platform_name
     );
-#else
-    printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2019 SUSE LLC <<<\n",
-      config.product
-    );
-#endif
     if (config.linemode)
       putchar('\n');
     fflush(stdout);

--- a/util.c
+++ b/util.c
@@ -452,7 +452,14 @@ void util_print_banner (void)
 
     uname (&utsinfo_ri);
     if (config.linemode) {
-      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) <<<\n", utsinfo_ri.release);
+#ifdef __s390x__
+      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) on %s <<<\n", 
+              utsinfo_ri.release,
+              config.hwp.machine_name);
+#else
+      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) <<<\n", 
+              utsinfo_ri.release);
+#endif
         return;
     }
     memset (&win_ri, 0, sizeof (window_t));
@@ -483,8 +490,14 @@ void util_print_banner (void)
     win_ri.style = STYLE_SUNKEN;
     win_open (&win_ri);
 
+#ifdef __s390x__
+    sprintf (text_ti, ">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) on %s <<<",
+             utsinfo_ri.release,
+             config.hwp.machine_name);
+#else
     sprintf (text_ti, ">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) <<<",
              utsinfo_ri.release);
+#endif
     util_center_text (text_ti, max_x_ig - 4);
     disp_set_color (colors_prg->has_colors ? COL_BWHITE : colors_prg->msg_fg,
                     win_ri.bg_color);

--- a/util.c
+++ b/util.c
@@ -452,14 +452,9 @@ void util_print_banner (void)
 
     uname (&utsinfo_ri);
     if (config.linemode) {
-#ifdef __s390x__
-      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) on %s <<<\n", 
+      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) %s <<<\n", 
               utsinfo_ri.release,
-              config.hwp.machine_name);
-#else
-      printf (">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) <<<\n", 
-              utsinfo_ri.release);
-#endif
+              config.platform_name);
         return;
     }
     memset (&win_ri, 0, sizeof (window_t));
@@ -493,7 +488,7 @@ void util_print_banner (void)
 #ifdef __s390x__
     sprintf (text_ti, ">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) on %s <<<",
              utsinfo_ri.release,
-             config.hwp.machine_name);
+             config.platform_name);
 #else
     sprintf (text_ti, ">>> linuxrc " LXRC_FULL_VERSION " (Kernel %s) <<<",
              utsinfo_ri.release);


### PR DESCRIPTION
…ssorlinuxrc is running on, for mainframe systems only.

This is for feature jsc#SLE-9474. I have compiled it on all supported architectures, but only tested it on s390x. There will also need to be a change to the installation images to add /usr/lib64/libqc.so.2.0.0, and the symlink of /usr/lib64/libqc.so.2