### PR TITLE
Append EXTRA_CFLAGS to CFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC	= gcc
-CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
+CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign $(RPM_OPT_FLAGS)
 LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)

--- a/mkpsfu/Makefile
+++ b/mkpsfu/Makefile
@@ -1,5 +1,5 @@
 CC	 = gcc
-CFLAGS	 = -Wall -O2 -fomit-frame-pointer
+CFLAGS	 = -Wall -O2 -fomit-frame-pointer $(RPM_OPT_FLAGS)
 
 .PHONY: all fonts font1 font2 clean
 


### PR DESCRIPTION
I would like the package would respect $Optflags in OBS.
Thus I'm suggesting to append EXTRA_CFLAGS to CFLAGS. One can
then 'export EXTRA_CFLAGS=$Optflags'.