### PR TITLE
Fix building with -fno-common.

### DIFF
--- a/global.h
+++ b/global.h
@@ -736,7 +736,7 @@ typedef struct {
 
 } config_t;
 
-config_t config;
+extern config_t config;
 
 extern int             max_x_ig;
 extern int             max_y_ig;

--- a/scsi_rename.h
+++ b/scsi_rename.h
@@ -8,12 +8,12 @@ typedef struct {
   unsigned removed:1;
 } scsi_dev_t;
 
-scsi_dev_t **scsi_list;
-scsi_dev_t **cdrom_list;
-scsi_dev_t **disk_list;
-unsigned scsi_list_len;
-unsigned cdrom_list_len;
-unsigned disk_list_len;
+extern scsi_dev_t **scsi_list;
+extern scsi_dev_t **cdrom_list;
+extern scsi_dev_t **disk_list;
+extern unsigned scsi_list_len;
+extern unsigned cdrom_list_len;
+extern unsigned disk_list_len;
 
 void get_scsi_list(void);
 void free_scsi_list(void);


### PR DESCRIPTION
The option will be default in GCC 10 and it fixes:
```
/usr/bin/ld: checkmedia.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: dialog.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: display.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: file.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: fstype.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: global.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: info.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: install.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: keyboard.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: linuxrc.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: module.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: net.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:11: multiple definition of `scsi_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:11: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:14: multiple definition of `scsi_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:14: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:12: multiple definition of `cdrom_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:12: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:15: multiple definition of `cdrom_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:15: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:13: multiple definition of `disk_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:13: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/scsi_rename.h:16: multiple definition of `disk_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:16: first defined here
/usr/bin/ld: scsi_rename.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: settings.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: slp.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: url.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:14: multiple definition of `scsi_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:14: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:11: multiple definition of `scsi_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:11: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:16: multiple definition of `disk_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:16: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:15: multiple definition of `cdrom_list_len'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:15: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:13: multiple definition of `disk_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:13: first defined here
/usr/bin/ld: util.o:/home/marxin/Programming/linuxrc/scsi_rename.h:12: multiple definition of `cdrom_list'; linuxrc.o:/home/marxin/Programming/linuxrc/scsi_rename.h:12: first defined here
/usr/bin/ld: window.o:/home/marxin/Programming/linuxrc/global.h:739: multiple definition of `config'; auto2.o:/home/marxin/Programming/linuxrc/global.h:739: first defined here
```