### PR TITLE
Revert "Append RPM_OPT_FLAGS to CFLAGS." (bsc#1158996)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC	= gcc
-CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign $(RPM_OPT_FLAGS)
+CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
 LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 ARCH	= $(shell /usr/bin/uname -m)
 ifeq ($(ARCH),s390x)

--- a/mkpsfu/Makefile
+++ b/mkpsfu/Makefile
@@ -1,5 +1,5 @@
 CC	 = gcc
-CFLAGS	 = -Wall -O2 -fomit-frame-pointer $(RPM_OPT_FLAGS)
+CFLAGS	 = -Wall -O2 -fomit-frame-pointer
 
 .PHONY: all fonts font1 font2 clean
 


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1158996

On some ppc64le setups, linuxrc runs into "stack smashing detected" and crashes.

## Solution

Revert https://github.com/openSUSE/linuxrc/pull/204. This avoids compiling with `$RPM_OPT_FLAGS`.

That's of course not the final solution but it gets linuxrc going until the real cause has been identified.