### PR TITLE
rework extension handling in linuxrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 CC	= gcc
 CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
-LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
+CFLAGS += -fmessage-length=0 -grecord-gcc-switches -fstack-protector-strong -fstack-protector-all \
+          -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection \
+          -fsanitize=address
+LDFLAGS	= -lasan -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 ARCH	= $(shell /usr/bin/uname -m)
 ifeq ($(ARCH),s390x)
 LDFLAGS	+= -lqc

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC	= gcc
 CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
-CFLAGS += -fmessage-length=0 -grecord-gcc-switches -fstack-protector-strong -fstack-protector-all \
-          -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection \
-          -fsanitize=address -fsanitize-recover=all
+ CFLAGS += -fmessage-length=0 -grecord-gcc-switches -D_FORTIFY_SOURCE=2 -fstack-protector-strong \
+          -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection
+#          -fsanitize=address -fsanitize-recover=all
 LDFLAGS	= -lasan -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 ARCH	= $(shell /usr/bin/uname -m)
 ifeq ($(ARCH),s390x)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC	= gcc
 CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
 CFLAGS += -fmessage-length=0 -grecord-gcc-switches -fstack-protector-strong -fstack-protector-all \
           -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection \
-          -fsanitize=address
+          -fsanitize=address -fsanitize-recover=all
 LDFLAGS	= -lasan -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 ARCH	= $(shell /usr/bin/uname -m)
 ifeq ($(ARCH),s390x)

--- a/auto2.c
+++ b/auto2.c
@@ -1120,8 +1120,17 @@ int auto2_add_extension(char *extension)
   char *argv[3] = { };
   char *s, *cmd = NULL;
   slist_t *sl;
+  char xxx[8];
 
   log_info("instsys add extension: %s\n", extension);
+
+  if(config.test) {
+    log_info("test mode - do nothing\n");
+    update_device_list(0);
+    xxx[12] = 9;
+    fprintf(stderr, "%s\n", xxx);
+    return 0;
+  }
 
   str_copy(&config.mountpoint.instdata, new_mountpoint());
   str_copy(&config.mountpoint.instsys, new_mountpoint());
@@ -1197,6 +1206,11 @@ int auto2_remove_extension(char *extension)
   slist_t *sl0 = NULL, *sl;
 
   log_info("instsys remove extension: %s\n", extension);
+
+  if(config.test) {
+    log_info("test mode - do nothing\n");
+    return 0;
+  }
 
   s = url_instsys_base(config.url.instsys->path);
   if(!s) return 3;

--- a/auto2.c
+++ b/auto2.c
@@ -1120,15 +1120,11 @@ int auto2_add_extension(char *extension)
   char *argv[3] = { };
   char *s, *cmd = NULL;
   slist_t *sl;
-  char xxx[8];
 
   log_info("instsys add extension: %s\n", extension);
 
   if(config.test) {
     log_info("test mode - do nothing\n");
-    update_device_list(0);
-    xxx[12] = 9;
-    fprintf(stderr, "%s\n", xxx);
     return 0;
   }
 

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1500,7 +1500,7 @@ void find_shell()
 void lxrc_usr1(int signum)
 {
   static unsigned extend_cnt = 0;
-  int i, err = 0;
+  int err = 0;
   char *s, buf[1024];
   FILE *f;
   slist_t *sl = NULL, *sl_task = NULL;
@@ -1531,18 +1531,28 @@ void lxrc_usr1(int signum)
       else if(task == 'r' && sl) {
         str_copy(&sl->key, NULL);
       }
-      if(!fork()) {
+
+      pid_t child_pid = fork();
+
+      if(!child_pid) {
         config.extend_running = 1;
 
         log_debug("=== extend started ===\n");
 
-        for(i = 0; i < 3; i++) close(i);
 
         // get us a copy of the logs
         unlink("/tmp/extend.log");
         str_copy(&config.log.dest[1].name, "/tmp/extend.log");
-        config.log.dest[1].f = NULL;
+        config.log.dest[1].f = fopen(config.log.dest[1].name, "a");
         config.log.dest[1].level = LOG_LEVEL_SHOW | LOG_LEVEL_INFO | LOG_LEVEL_DEBUG | LOG_TIMESTAMP;
+
+        // close stdin, stdout and stderr point to log file
+        close(0);
+        if(config.log.dest[1].f) {
+          int fd = fileno(config.log.dest[1].f);
+          dup2(fd, 1);
+          dup2(fd, 2);
+        }
 
         config.download.cnt = 1000 + extend_cnt;
         config.mountpoint.cnt = 1000 + extend_cnt;
@@ -1575,8 +1585,12 @@ void lxrc_usr1(int signum)
         config.log.dest[1].level = 0;
         log_debug("=== extend finished ===\n");
 
-        if(extend_pid > 0) kill(extend_pid, SIGUSR1);
         exit(0);
+      }
+      else {
+        // wait for child to finish, then signal extend command to go on
+        waitpid(child_pid, NULL, 0);
+        if(extend_pid > 0) kill(extend_pid, SIGUSR1);
       }
     }
   }

--- a/util.c
+++ b/util.c
@@ -2705,6 +2705,9 @@ int util_extend(char *extension, char task, int verbose)
         fscanf(f, "%d", &err);
         fclose(f);
       }
+      else {
+        err = 1;
+      }
     }
   }
   else {


### PR DESCRIPTION
In case the extension task crashes unexpectedly, the 'extend' command
returns an error instead of locking up.