### PR TITLE
rework 'extend' command to log and report an error if linuxrc unexpectedly crashes (bsc#1158996)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC	= gcc
-CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign
+CFLAGS	= -c -g -O2 -Wall -Wno-pointer-sign $(RPM_OPT_FLAGS)
 LDFLAGS	= -rdynamic -lhd -lblkid -lcurl -lreadline -lmediacheck
 ARCH	= $(shell /usr/bin/uname -m)
 ifeq ($(ARCH),s390x)

--- a/auto2.c
+++ b/auto2.c
@@ -1123,6 +1123,11 @@ int auto2_add_extension(char *extension)
 
   log_info("instsys add extension: %s\n", extension);
 
+  if(config.test) {
+    log_info("test mode - do nothing\n");
+    return 0;
+  }
+
   str_copy(&config.mountpoint.instdata, new_mountpoint());
   str_copy(&config.mountpoint.instsys, new_mountpoint());
 
@@ -1197,6 +1202,11 @@ int auto2_remove_extension(char *extension)
   slist_t *sl0 = NULL, *sl;
 
   log_info("instsys remove extension: %s\n", extension);
+
+  if(config.test) {
+    log_info("test mode - do nothing\n");
+    return 0;
+  }
 
   s = url_instsys_base(config.url.instsys->path);
   if(!s) return 3;

--- a/mkpsfu/Makefile
+++ b/mkpsfu/Makefile
@@ -1,5 +1,5 @@
 CC	 = gcc
-CFLAGS	 = -Wall -O2 -fomit-frame-pointer
+CFLAGS	 = -Wall -O2 -fomit-frame-pointer $(RPM_OPT_FLAGS)
 
 .PHONY: all fonts font1 font2 clean
 

--- a/util.c
+++ b/util.c
@@ -2705,6 +2705,9 @@ int util_extend(char *extension, char task, int verbose)
         fscanf(f, "%d", &err);
         fclose(f);
       }
+      else {
+        err = 1;
+      }
     }
   }
   else {


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1158996
- https://trello.com/c/UpuZNwxv

The `extend` command hangs forever on ppc64 due to a stack smashing by glibc's `backtrace()` function. The stack smashing was revealed by the stack protection options included in `$RPM_OPT_FLAGS`.

## Solution

- Rework `extend` so it doesn't wait forever for linuxrc to finish. Instead it returns an error if a crash happens.

And, since glibc has been fixed:

- Re-enable `$RPM_OPT_FLAGS`.