### PR TITLE
For bsc#1161701, Moved the logic to retrieve the platform name into a

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1759,12 +1759,12 @@ void select_repo_url(char *msg, char **repo)
 
 char * get_platform_name()
 {
+  char *platform = NULL;
 #if defined(__s390__) || defined(__s390x__)
   void *qc_configuration_handle = NULL;
   const char *qc_result_string = NULL;
   int qc_return_code = 0;
   int qc_get_return_code = 0;
-  char *platform = NULL;
 
   qc_configuration_handle = qc_open(&qc_return_code);
   if (qc_return_code==0)
@@ -1780,7 +1780,7 @@ char * get_platform_name()
 
   qc_close(qc_configuration_handle);
 #else
-  &platform="";
+  str_copy(&platform, "");
 #endif
 return platform;
 }

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -902,7 +902,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2019 SUSE LLC %s <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2020 SUSE LLC %s <<<\n",
       config.product,
       config.platform_name
     );


### PR DESCRIPTION
subroutine, and moved the invocation of it until after the call to
lxrc_add_parts so that the squashfs files have been loopback mounted.