### PR TITLE
move plymouthd start after screen size detection (bsc #1163115)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -992,8 +992,6 @@ void lxrc_init()
   // now that udev is up and running, some URLs might be parsed differently
   util_reparse_blockdev_urls();
 
-  if(config.plymouth) util_run_script("plymouth_setup");
-
   util_free_mem();
 
   if(config.memoryXXX.free < config.memoryXXX.min_free) {
@@ -1012,10 +1010,6 @@ void lxrc_init()
     freopen(config.console, "a", stdout);
   }
 
-  util_get_splash_status();
-
-  util_splash_bar(10, SPLASH_10);
-
   if(util_check_exist("/proc/iSeries")) {
     config.is_iseries = 1;
     config.linemode = 1;
@@ -1027,6 +1021,12 @@ void lxrc_init()
 
   // clear keyboard queue
   while(kbd_getch_old(0));
+
+  if(config.plymouth) util_run_script("plymouth_setup");
+
+  util_get_splash_status();
+
+  util_splash_bar(10, SPLASH_10);
 
   set_activate_language(config.language);
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1163115
- https://trello.com/c/ms95Xya0

installation stalls after loading the inst-sys images because `plymouth quit` hangs indefinitely.

## Analysis

This is because [get_screen_size()](https://github.com/openSUSE/linuxrc/blob/master/keyboard.c#L477) might potentially interfere with plymouthd as both linuxrc and plymouthd might try to read from the same serial line.

It is however unclear why  plymouthd runs on a serial line as it is started with `plymouthd --tty=tty1` which should restrict it to `/dev/tty1`. But apparently this does not work since sle15-sp1.

- https://bugzilla.suse.com/show_bug.cgi?id=1164123

## Solution

Start plymouthd after all the console init stuff has been done by linuxrc to be on the safe side.

## See also

The same for SLE15-SP1: https://github.com/openSUSE/linuxrc/pull/215