### PR TITLE
Try suboption for ifcfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - docker run --rm -it linuxrc-image rpm -qa | sort
 
 script:
-  - docker run --rm -it -e TRAVIS=1 linuxrc-image bash -c "make -j `nproc` && ./smoke_test.sh"
+  - docker run --rm -it -e TRAVIS=1 --privileged linuxrc-image bash -c "make -j `nproc` && ./smoke_test.sh"

--- a/auto2.c
+++ b/auto2.c
@@ -136,6 +136,7 @@ int auto2_init()
         else
         {
           log_debug("auto2_init: Cannot find another device to try");
+          break;
         }
       }
     }

--- a/auto2.c
+++ b/auto2.c
@@ -611,7 +611,7 @@ void auto2_user_netconfig()
   if(!net_config_needed(0)) return;
 
   check_ptp(config.ifcfg.manual->device);
-  
+
   if( ((net_config_mask() & 3) == 3) || (config.ifcfg.manual->ptp && ((net_config_mask() & 1) == 1)) ) {
     /* we have IP & netmask (or just IP for PTP devices) */
     config.net.configured = nc_static;

--- a/auto2.c
+++ b/auto2.c
@@ -135,17 +135,7 @@ int auto2_init()
         }
         else
         {
-          // we don't need the search_list anymore -> release it
-          ifcfg_t * ifcfg = search_list;
-
           log_debug("auto2_init: Cannot find another device to try");
-
-          while( ifcfg)
-          {
-            search_list = ifcfg->next;
-            free(ifcfg);
-            ifcfg = search_list;
-          }
         }
       }
     }

--- a/global.h
+++ b/global.h
@@ -631,7 +631,6 @@ typedef struct {
   struct {
     unsigned dhcp_active:1;	/**< dhcpd is running */
     unsigned ifconfig:1;	/**< setup network interface */
-    unsigned is_configured:1;	/**< set if network is configured */
     unsigned all_ifs:1;		/**< try all interfaces */
     unsigned now:1;		/**< configure network _now_ */
     unsigned ipv4:1;		/**< do ipv4 config */

--- a/global.h
+++ b/global.h
@@ -639,6 +639,7 @@ typedef struct {
     unsigned dhcp_timeout_set:1;	/**< dhcp_timeout was set explicitly */
     unsigned sethostname:1;	/**< wicked should set hostname */
     unsigned sethostname_used:1;	/**< user has used linuxrc's SetHostname option */
+    unsigned search:1;          /**< search for matching iface which can access installation */
     unsigned do_setup;		/**< do network setup */
     unsigned setup;		/**< bitmask: do these network setup things */
     char *device;		/**< currently used device */

--- a/global.h
+++ b/global.h
@@ -694,6 +694,7 @@ typedef struct {
 
   struct {
     ifcfg_t *list;		/**< list of ifcfg entries */
+    ifcfg_t *parsed_input;      /**< what we got after parsing ifcfg option **/
     ifcfg_t *manual;		/**< ifcfg data for manual network setup */
     ifcfg_t *all;		/**< all we ever did, kept for debugging */
     slist_t *initial;		/**< list of initially set up network interfaces */

--- a/global.h
+++ b/global.h
@@ -310,6 +310,7 @@ typedef struct ifcfg_s {
   unsigned used:1;	///< config has been used
   unsigned pattern:1;	///< 'device' is shell glob
   unsigned ptp:1;	///< ptp config, gw is ptp peer
+  unsigned search:1;    ///< whether "try" feature is enabled for this ifcfg
   int netmask_prefix;	///< prefix given via netmask option and only used if an ip doen't have one
   char *vlan;		///< vlan id, if any
   char *ip;		///< list of ip addresses, space separated

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1189,23 +1189,12 @@ void lxrc_init()
   // - net_update_ifcfg releases the list otherwise
   if(config.net.search && config.ifcfg.list)
   {
-    ifcfg_t * ifcfg = NULL;
-
     log_debug("Creating search list for try option");
 
-    for( ifcfg = config.ifcfg.list; ifcfg; ifcfg = ifcfg->next)
+    if(!ifcfg_list_copy(&search_list, config.ifcfg.list))
     {
-      ifcfg_t *clone = calloc(1, sizeof *ifcfg);
-
-      if( !clone)
-      {
-        log_debug("Cannot create list for try option");
-        config.net.search = 0;
-        break;
-      }
-
-      ifcfg_copy( clone, ifcfg);
-      ifcfg_append( &search_list, clone);
+      log_debug("List creation failed -> disabling try option");
+      config.net.search = 0;
     }
   }
 

--- a/net.c
+++ b/net.c
@@ -2430,6 +2430,13 @@ ifcfg_t *ifcfg_parse(char *str)
   }
 
   s = slist_key(sl0, 1);
+  if(s && (strncmp(s, "try", sizeof "try" -1) == 0))
+  {
+    log_debug("Will try to detect interface with access to installation");
+    config.net.search = 1;
+    s = slist_key(sl0, 2);
+  }
+
   if(s && !strncmp(s, "dhcp", sizeof "dhcp" - 1)) {
     str_copy(&ifcfg->type, s);
     ifcfg->dhcp = 1;

--- a/net.c
+++ b/net.c
@@ -113,9 +113,6 @@ void net_ask_password()
  *      0: ok
  *   != 0: error or abort
  *
- * Global vars changed:
- *  config.net.is_configured
- *
  * Does nothing if DHCP is active.
  *
  * FIXME: needs window mode or not?
@@ -199,9 +196,6 @@ int net_config()
 /*
  * Shut down all network interfaces.
  *
- * Global vars changed:
- *  config.net.is_configured
- *
  * config.net.device:    interface
  * /proc/net/route: configured interfaces
  */
@@ -214,12 +208,10 @@ void net_stop()
   log_debug("%s: network down\n", device);
 
   if(config.test) {
-    config.net.is_configured = nc_none;
     return;
   }
 
   net_wicked_down(device);
-  config.net.is_configured = nc_none;
 
   // delete current config
   if(config.ifcfg.current) {

--- a/net.c
+++ b/net.c
@@ -2507,6 +2507,35 @@ void ifcfg_copy(ifcfg_t *dst, ifcfg_t *src)
   str_copy(&dst->domain, src->domain);
 }
 
+/*
+ * Deep copy of list of icfg_t structs
+ *
+ * Content of dst list is ignored.
+ *
+ * Return 0 in case of failure, 1 otherwise
+ */
+int ifcfg_list_copy(ifcfg_t **dst, ifcfg_t *src)
+{
+  if( !dst || !src)
+    return 0;
+
+  for( ; src; src = src->next)
+  {
+    *dst = calloc(1, sizeof *src);
+
+    if( !(*dst))
+    {
+      log_debug("ifcfg_list_copy: memory allocation failed");
+      return 0;
+    }
+
+    ifcfg_copy( *dst, src);
+    dst = &(*dst)->next;
+  }
+
+  return 1;
+}
+
 
 ifcfg_t *ifcfg_append(ifcfg_t **p0, ifcfg_t *p)
 {

--- a/net.h
+++ b/net.h
@@ -40,3 +40,4 @@ unsigned check_ptp(char *ifname);
 void net_wicked_get_config_keys(void);
 void net_nanny(void);
 char *net_get_ifname(ifcfg_t *ifcfg);
+int net_try_next_device(ifcfg_t *list, int flags, int attempt);

--- a/net.h
+++ b/net.h
@@ -30,6 +30,7 @@ void net_update_ifcfg(int flags);
 ifcfg_t *ifcfg_parse(char *str);
 ifcfg_t *ifcfg_append(ifcfg_t **p0, ifcfg_t *p);
 void ifcfg_copy(ifcfg_t *dst, ifcfg_t *src);
+int ifcfg_list_copy(ifcfg_t **dst, ifcfg_t *src);
 char *ifcfg_print(ifcfg_t *ifcfg);
 void net_update_state(void);
 void net_wicked_up(char *ifname);

--- a/net.h
+++ b/net.h
@@ -41,3 +41,4 @@ void net_wicked_get_config_keys(void);
 void net_nanny(void);
 char *net_get_ifname(ifcfg_t *ifcfg);
 int net_try_next_device(ifcfg_t *list, int flags, int attempt);
+int net_perform_search(ifcfg_t * search_list, int attempt);


### PR DESCRIPTION
https://trello.com/c/WJmotQTM/1548-5-feature-sle-8965-additional-try-option-for-linuxrc-ifcfg-network-setup

## Problem ##

We were asked for implementing a feature, when static configuration is tried on net devices one-by-one until net installation source can be reached.

## Solution ##

The suboption makes sense only for static configuration with pattern instead of particular device. Each ifcfg configuration is assigned to each matching device. After assigning another device, we restart installation  and check whether it can reach the installation image. Only ifcfg configs marked with try suboption are handled when searching matching device.