### PR TITLE
parse 'try' keyword in ifcfg option (jsc#SLE-8965, jsc#SLE-9791)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - docker run --rm -it linuxrc-image rpm -qa | sort
 
 script:
-  - docker run --rm -it -e TRAVIS=1 linuxrc-image bash -c "make -j `nproc` && ./smoke_test.sh"
+  - docker run --rm -it -e TRAVIS=1 --privileged linuxrc-image bash -c "make -j `nproc` && ./smoke_test.sh"

--- a/file.c
+++ b/file.c
@@ -1715,7 +1715,18 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         break;
 
       case key_ifcfg:
-        if(*f->value) ifcfg_append(&config.ifcfg.list, ifcfg_parse(f->value));
+        if(*f->value) {
+          ifcfg_t *ifcfg = ifcfg_parse(f->value);
+          if(ifcfg) {
+            // if 'try' flag is set, move to config.ifcfg.manual
+            if(ifcfg->search) {
+              ifcfg_copy(config.ifcfg.manual, ifcfg);
+            }
+            else {
+              ifcfg_append(&config.ifcfg.list, ifcfg);
+            }
+          }
+        }
         break;
 
       case key_defaultinstall:

--- a/global.h
+++ b/global.h
@@ -632,7 +632,6 @@ typedef struct {
   struct {
     unsigned dhcp_active:1;	/**< dhcpd is running */
     unsigned ifconfig:1;	/**< setup network interface */
-    unsigned is_configured:1;	/**< set if network is configured */
     unsigned all_ifs:1;		/**< try all interfaces */
     unsigned now:1;		/**< configure network _now_ */
     unsigned ipv4:1;		/**< do ipv4 config */

--- a/global.h
+++ b/global.h
@@ -310,6 +310,7 @@ typedef struct ifcfg_s {
   unsigned used:1;	///< config has been used
   unsigned pattern:1;	///< 'device' is shell glob
   unsigned ptp:1;	///< ptp config, gw is ptp peer
+  unsigned search:1;    ///< whether "try" feature is enabled for this ifcfg
   int netmask_prefix;	///< prefix given via netmask option and only used if an ip doen't have one
   char *vlan;		///< vlan id, if any
   char *ip;		///< list of ip addresses, space separated

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1206,7 +1206,7 @@ void lxrc_init()
     util_disp_init();
 
     if(util_check_exist("/nextmedia") == 'r') {
-      config.cd1texts = file_parse_xmllike("/nextmedia", "text");  
+      config.cd1texts = file_parse_xmllike("/nextmedia", "text");
     }
 
     char *next_msg = get_translation(config.cd1texts, current_language()->locale);

--- a/net.c
+++ b/net.c
@@ -2395,6 +2395,7 @@ ifcfg_t *ifcfg_parse(char *str)
   slist_t *sl, *sl0, *slx;
   ifcfg_t *ifcfg;
   char *s, *t;
+  int try_shift = 0; // try keyword is optional, so position of following params can vary
 
   if(!str) return NULL;
 
@@ -2430,6 +2431,16 @@ ifcfg_t *ifcfg_parse(char *str)
   }
 
   s = slist_key(sl0, 1);
+  if(s && (strncmp(s, "try", sizeof "try" -1) == 0))
+  {
+    log_debug("Will try to detect interface with access to installation");
+
+    ifcfg->search = 1;
+    try_shift = 1;
+
+    s = slist_key(sl0, 2);
+  }
+
   if(s && !strncmp(s, "dhcp", sizeof "dhcp" - 1)) {
     str_copy(&ifcfg->type, s);
     ifcfg->dhcp = 1;
@@ -2441,13 +2452,13 @@ ifcfg_t *ifcfg_parse(char *str)
 
     if(s && *s && !(t = strchr(s, '='))) str_copy(&ifcfg->ip, s);
 
-    s = slist_key(sl0, 2);
+    s = slist_key(sl0, 2 + try_shift);
     if(!t && s && *s && !(t = strchr(s, '='))) str_copy(&ifcfg->gw, s);
 
-    s = slist_key(sl0, 3);
+    s = slist_key(sl0, 3 + try_shift);
     if(!t && s && *s && !(t = strchr(s, '='))) str_copy(&ifcfg->ns, s);
 
-    s = slist_key(sl0, 4);
+    s = slist_key(sl0, 4 + try_shift);
     if(!t && s && *s && !(t = strchr(s, '='))) str_copy(&ifcfg->domain, s);
   }
 
@@ -2486,11 +2497,14 @@ void ifcfg_copy(ifcfg_t *dst, ifcfg_t *src)
 
   str_copy(&dst->device, src->device);
   str_copy(&dst->type, src->type);
+
   dst->dhcp = src->dhcp;
   dst->used = src->used;
   dst->pattern = src->pattern;
   dst->ptp = src->ptp;
+  dst->search = src->search;
   dst->netmask_prefix = src->netmask_prefix;
+
   str_copy(&dst->vlan, src->vlan);
   str_copy(&dst->ip, src->ip);
   str_copy(&dst->gw, src->gw);
@@ -2520,10 +2534,10 @@ char *ifcfg_print(ifcfg_t *ifcfg)
   if(ifcfg->vlan) strprintf(&buf, "%s  vlan = %s\n", buf, ifcfg->vlan);
   if(ifcfg->type) strprintf(&buf, "%s  type = %s\n", buf, ifcfg->type);
   strprintf(&buf,
-    "%s  dhcp = %u, pattern = %u, used = %u, prefix = %d, ptp = %u\n",
+    "%s  dhcp = %u, pattern = %u, used = %u, prefix = %d, ptp = %u, search = %u\n",
     buf,
     ifcfg->dhcp, ifcfg->pattern, ifcfg->used,
-    ifcfg->netmask_prefix, ifcfg->ptp
+    ifcfg->netmask_prefix, ifcfg->ptp, ifcfg->search
   );
   if(ifcfg->ip) strprintf(&buf, "%s  ip = %s\n", buf, ifcfg->ip);
   if(ifcfg->gw) strprintf(&buf, "%s  gw = %s\n", buf, ifcfg->gw);

--- a/net.c
+++ b/net.c
@@ -113,9 +113,6 @@ void net_ask_password()
  *      0: ok
  *   != 0: error or abort
  *
- * Global vars changed:
- *  config.net.is_configured
- *
  * Does nothing if DHCP is active.
  *
  * FIXME: needs window mode or not?
@@ -199,9 +196,6 @@ int net_config()
 /*
  * Shut down all network interfaces.
  *
- * Global vars changed:
- *  config.net.is_configured
- *
  * config.net.device:    interface
  * /proc/net/route: configured interfaces
  */
@@ -214,12 +208,10 @@ void net_stop()
   log_debug("%s: network down\n", device);
 
   if(config.test) {
-    config.net.is_configured = nc_none;
     return;
   }
 
   net_wicked_down(device);
-  config.net.is_configured = nc_none;
 
   // delete current config
   if(config.ifcfg.current) {

--- a/url.c
+++ b/url.c
@@ -1776,7 +1776,7 @@ int url_mount(url_t *url, char *dir, int (*test_func)(url_t *))
   char *hwaddr;
   hd_hw_item_t hw_items[3] = { hw_network_ctrl, hw_network, 0 };
   str_list_t *sl;
-  char *url_device;
+  char *url_device = NULL;
 
   if(!url || !url->scheme) return 1;
 
@@ -1806,8 +1806,8 @@ int url_mount(url_t *url, char *dir, int (*test_func)(url_t *))
     hw_items[1] = 0;
   }
 
-  url_device = url->device;
-  if(!url_device) url_device = url->is.network ? config.ifcfg.manual->device : config.device;
+  str_copy(&url_device, url->device);
+  if(!url_device) str_copy(&url_device, url->is.network ? config.ifcfg.manual->device : config.device);
 
   for(found = 0, hd = sort_a_bit(fix_device_names(hd_list2(config.hd_data, hw_items, 0))); hd; hd = hd->next) {
     for(hwaddr = NULL, res = hd->res; res; res = res->next) {
@@ -1885,6 +1885,8 @@ int url_mount(url_t *url, char *dir, int (*test_func)(url_t *))
     str_copy(&url->used.hwaddr, NULL);
     str_copy(&url->used.unique_id, NULL);
   }
+
+  str_copy(&url_device, NULL);
 
   return found ? 0 : 1;
 }
@@ -2413,7 +2415,7 @@ int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *la
   hd_res_t *res;
   char *hwaddr;
   str_list_t *sl;
-  char *url_device;
+  char *url_device = NULL;
   hd_hw_item_t hw_items[] = { hw_network_ctrl, hw_network, 0 };
 
   if(!url || !url->is.network || config.ifcfg.if_up) return url_read_file(url, dir, src, dst, label, flags);
@@ -2429,7 +2431,7 @@ int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *la
   LXRC_WAIT
 
   if(config.hd_data) {
-    url_device = url->device ?: config.ifcfg.manual->device;
+    str_copy(&url_device, url->device ?: config.ifcfg.manual->device);
 
     for(found = 0, hd = sort_a_bit(hd_list2(config.hd_data, hw_items, 0)); hd; hd = hd->next) {
       for(hwaddr = NULL, res = hd->res; res; res = res->next) {
@@ -2471,6 +2473,8 @@ int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *la
       str_copy(&url->used.hwaddr, NULL);
       str_copy(&url->used.unique_id, NULL);
     }
+
+    str_copy(&url_device, NULL);
 
     LXRC_WAIT
 


### PR DESCRIPTION
## Task

- https://trello.com/c/WJmotQTM

Add ´try` keyword to `ifcfg` option.

## Solution

This is the parser code from https://github.com/openSUSE/linuxrc/pull/217 but using the simpler approach of copying the ifcfg value to `config.ifcfg.manual` - which is already used for exactly the intended purpose (iterating through network device list until an interface works).