### PR TITLE
make I/O device pre-configuration optional (bsc#1168036, jsc#SLE-7396)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -57,6 +57,7 @@ struct {
   { di_set_usessh,       "Enable or Disable SSH Mode",          },
   { di_set_startshell,   "Start shell before and after YaST?",    },
   { di_set_slp,          "Get SLP info",        },
+  { di_set_auto_config,  "I/O device pre-configuration" },
 
   { di_inst_install,     "Installation",       },
   { di_inst_update,      "Upgrade",       },

--- a/dialog.c
+++ b/dialog.c
@@ -57,7 +57,7 @@ struct {
   { di_set_usessh,       "Enable or Disable SSH Mode",          },
   { di_set_startshell,   "Start shell before and after YaST?",    },
   { di_set_slp,          "Get SLP info",        },
-  { di_set_auto_config,  "I/O device pre-configuration" },
+  { di_set_auto_config,  "I/O device auto-configuration" },
 
   { di_inst_install,     "Installation",       },
   { di_inst_update,      "Upgrade",       },

--- a/dialog.h
+++ b/dialog.h
@@ -43,6 +43,7 @@ typedef enum {
   di_set_usessh,
   di_set_startshell,
   di_set_slp,
+  di_set_auto_config,
 
   di_inst_install,
   di_inst_update,

--- a/file.c
+++ b/file.c
@@ -316,6 +316,7 @@ static struct {
   { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
   { key_norepo,         "NoRepo",         kf_cfg + kf_cmd                },
   { key_auto_assembly,  "AutoAssembly",   kf_cfg + kf_cmd_early          },
+  { key_device_auto_config, "DeviceAutoConfig",  kf_cfg + kf_cmd_early   },
 };
 
 static struct {
@@ -328,6 +329,7 @@ static struct {
   { "yes",       1                  },
   { "j",         1                  },	// keep for compatibility?
   { "default",   1                  },
+  { "ask",       2                  },
   { "Undef",     0                  },
   { "Mono",      1                  },
   { "Color",     2                  },
@@ -1796,6 +1798,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_auto_assembly:
         if(f->is.numeric) config.auto_assembly = f->nvalue;
+        break;
+
+      case key_device_auto_config:
+        if(f->is.numeric) config.device_auto_config = f->nvalue;
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -56,7 +56,8 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse
+  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
+  key_device_auto_config
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -450,6 +450,8 @@ typedef struct {
   unsigned norepo:1;            /**< disable repo location check, expect YaST */
   unsigned auto_assembly:1;	/**< enable MD/RAID auto-assembly */
   unsigned autoyast_parse:1;	/**< analyse autoyast parameter */
+  unsigned device_auto_config:2;	/**< run s390 device auto-config (cf. bsc#1168036) */
+  unsigned device_auto_config_done:1;	/**< set after s390 device auto-config has been run */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -808,6 +808,9 @@ void lxrc_init()
   config.kexec = 2;		/* kexec if necessary, with user dialog */
   config.auto_assembly = 0;	/* default to disable MD/RAID auto-assembly (bsc#1132688) */
   config.autoyast_parse = 1;	/* analyse autoyast option and read autoyast file */
+#if defined(__s390x__)
+  config.device_auto_config = 2;	/* ask before doing s390 device auto config */
+#endif
 
   // defaults for self-update feature
   config.self_update_url = NULL;
@@ -1043,6 +1046,8 @@ void lxrc_init()
   log_show(" ok\n");
 
   LXRC_WAIT
+
+  util_device_auto_config();
 
   /* look for driver updates in initrd */
   util_chk_driver_update("/", "/");

--- a/settings.c
+++ b/settings.c
@@ -181,6 +181,9 @@ int set_settings()
     di_set_startshell,
     di_set_slp,
     di_inst_net_config,
+#if defined(__s390x__)
+    di_set_auto_config,
+#endif
     di_none
   };
 
@@ -299,6 +302,12 @@ int set_settings_cb (dia_item_t di)
 
     case di_inst_net_config:
       net_config();
+      rc = 1;
+      break;
+
+    case di_set_auto_config:
+      config.device_auto_config = 2;
+      util_device_auto_config();
       rc = 1;
       break;
 

--- a/util.c
+++ b/util.c
@@ -1204,6 +1204,7 @@ void util_status_info(int log_it)
   add_flag(&sl0, buf, config.self_update, "self_update");
   add_flag(&sl0, buf, config.repomd, "repomd");
   add_flag(&sl0, buf, config.norepo, "norepo");
+  add_flag(&sl0, buf, config.device_auto_config, "deviceautoconfig");
   if(*buf) slist_append_str(&sl0, buf);
 
   if(config.self_update_url) {
@@ -5671,4 +5672,30 @@ void util_reparse_blockdev_urls()
   util_reparse_blockdev_url(&config.url.autoyast2);
   util_reparse_blockdev_url(&config.url.install);
   util_reparse_blockdev_url(&config.url.instsys);
+}
+
+/*
+ * Apply S390 I/O device auto-config.
+ *
+ * Ask user before doing so, if requested.
+ */
+void util_device_auto_config()
+{
+  unsigned do_it = config.device_auto_config;
+
+  if(do_it == 2) {
+    int win_old = config.win;
+    char *msg = config.device_auto_config_done ?
+      "Reapply I/O device pre-configuration?" : "Apply I/O device pre-configuration?";
+
+    if(!config.win) util_disp_init();
+    do_it = dia_yesno(msg, YES) == YES;
+    if(config.win && !win_old) util_disp_done();
+  }
+
+  if(do_it) {
+    log_info("applying I/O device pre-configuration\n");
+    util_run_script("device_auto_config");
+    config.device_auto_config_done = 1;
+  }
 }

--- a/util.c
+++ b/util.c
@@ -121,6 +121,7 @@ static int cmp_alpha(slist_t *sl0, slist_t *sl1);
 static int cmp_alpha_s(const void *p0, const void *p1);
 static slist_t *get_kernel_list(char *dev);
 
+static int has_device_auto_config(void);
 
 void util_redirect_kmsg()
 {
@@ -5683,6 +5684,8 @@ void util_device_auto_config()
 {
   unsigned do_it = config.device_auto_config;
 
+  if(do_it && !has_device_auto_config()) do_it = 0;
+
   if(do_it == 2) {
     int win_old = config.win;
     char *msg = config.device_auto_config_done ?
@@ -5698,4 +5701,23 @@ void util_device_auto_config()
     util_run_script("device_auto_config");
     config.device_auto_config_done = 1;
   }
+}
+
+
+/*
+ * Check if S390 I/O device pre-config data is available.
+ */
+int has_device_auto_config()
+{
+  FILE *f;
+  int has_it = 0;
+
+  if((f = fopen("/sys/firmware/sclp_sd/config/data", "r"))) {
+    has_it = fgetc(f) != EOF;
+    fclose(f);
+  }
+
+  log_info("has I/O device pre-config data: %d\n", has_it);
+
+  return has_it;
 }

--- a/util.c
+++ b/util.c
@@ -5689,7 +5689,7 @@ void util_device_auto_config()
   if(do_it == 2) {
     int win_old = config.win;
     char *msg = config.device_auto_config_done ?
-      "Reapply I/O device pre-configuration?" : "Apply I/O device pre-configuration?";
+      "Reapply I/O device auto-configuration?" : "Apply I/O device auto-configuration?";
 
     if(!config.win) util_disp_init();
     do_it = dia_yesno(msg, YES) == YES;
@@ -5697,7 +5697,7 @@ void util_device_auto_config()
   }
 
   if(do_it) {
-    log_info("applying I/O device pre-configuration\n");
+    log_info("applying I/O device auto-configuration\n");
     util_run_script("device_auto_config");
     config.device_auto_config_done = 1;
   }
@@ -5705,7 +5705,7 @@ void util_device_auto_config()
 
 
 /*
- * Check if S390 I/O device pre-config data is available.
+ * Check if S390 I/O device auto-config data is available.
  */
 int has_device_auto_config()
 {
@@ -5717,7 +5717,7 @@ int has_device_auto_config()
     fclose(f);
   }
 
-  log_info("has I/O device pre-config data: %d\n", has_it);
+  log_info("has I/O device auto-config data: %d\n", has_it);
 
   return has_it;
 }

--- a/util.h
+++ b/util.h
@@ -163,3 +163,5 @@ void util_write_active_devices(char *format, ...)  __attribute__ ((format (print
 
 void util_reparse_blockdev_url(url_t **url_ptr);
 void util_reparse_blockdev_urls(void);
+
+void util_device_auto_config(void);


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1168036
- https://jira.suse.com/browse/SLE-7396

I/O device pre-configuration should not be used unconditionally. The user needs a way to avoid it.

## Solution

Add a `DeviceAutoConfig` boot option which can be 0, 1, 2, resp. `no`, `yes`, `ask`.

If set to `ask` and pre-config data is avaibale, the user gets a confirmation dialog before using the device pre-config data. The default is `ask`.

There is also a menu item in `Main Menu -> Settings` that allows to apply the pre-config data manually.

## See also

- related installation-images change: https://github.com/openSUSE/installation-images/pull/368

## Screenshots

### Here's the dialog you see:

```
>>> SUSE Linux installation program v7.0.13 (c) 1996-2020 SUSE LLC  <<<
Loading basic drivers... ok

Apply I/O device auto-configuration?

0) <-- Back <--
1) Yes
2) No

> 
```

### It is also available via the UI:

```
>>> SUSE Linux installation program v7.0.13 (c) 1996-2020 SUSE LLC  <<<
Loading basic drivers... ok
>>> linuxrc 7.0.13 (Kernel 4.12.14-lp151.28.32-default)  <<<

Main Menu

0) <-- Back <--
1) Start Installation          
2) Settings               
3) Expert                
4) Exit or Reboot            

> 2

Settings

 0) <-- Back <--
 1) Language                
 2) Display                
 3) Keymap                 
 4) Animation               
 5) Load Root Image into RAM Disk     
 6) Enter Root Image            
 7) VNC Enable or Disable         
 8) Enable or Disable SSH Mode       
 9) Start shell before and after YaST?   
10) Get SLP info              
11) Network Setup             
12) I/O device auto-configuration      

> 12

Apply I/O device auto-configuration?

0) <-- Back <--
1) Yes
2) No

>
```