### PR TITLE
udevadm is in /usr/bin (bsc#1171587)

### DIFF
--- a/net.c
+++ b/net.c
@@ -1636,7 +1636,7 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
     return -1;
   }
 
-  rc = lxrc_run("/sbin/udevadm settle");
+  rc = lxrc_run("/usr/bin/udevadm settle");
   if(rc) {
     sprintf(cmd, "udevadm settle failed (error code %d)", rc);
     dia_message(cmd, MSGTYPE_ERROR);


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1171587

s390x device activation doesn't work correctly in TW.

## Solution

There was a usage of `/sbin/udevadm` left in the s390x network device setup code.