### PR TITLE
replace $releasever in URLs, similar to libzypp (bsc#1171018)

### DIFF
--- a/global.h
+++ b/global.h
@@ -265,7 +265,6 @@ typedef enum {
 typedef struct {
   char *str;
   instmode_t scheme;
-  instmode_t orig_scheme;
   char *server;
   char *share;
   char *path;
@@ -299,6 +298,16 @@ typedef struct {
     char *model;
     char *unique_id;
   } used;
+  struct {
+    /*
+     * The original values of some url components that might get modified in url_set().
+     */
+    instmode_t scheme;
+    char *server;
+    char *share;
+    char *path;
+    char *instsys;
+  } orig;
 } url_t;
 
 
@@ -494,6 +503,7 @@ typedef struct {
   char *serial;			/**< serial console parameters, e.g. ttyS0,38400 or ttyS1,9600n8 */
   char *product;		/**< product name */
   char *product_dir;		/**< product specific dir component (e.g. 'suse') */
+  char *releasever;		/**< product version, to be used for replacing $releasever in zypp */
   int kbdtimeout;		/**< keyboard timeout (in s) */
   int escdelay;			/**< timeout to differ esc from function keys */
   int loglevel;			/**< set kernel log level */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -856,6 +856,8 @@ void lxrc_init()
 
   config.platform_name=get_platform_name();
 
+  util_get_releasever();
+
   LXRC_WAIT
 
   if(util_check_exist("/sbin/mount.smbfs")) {

--- a/url.h
+++ b/url.h
@@ -51,6 +51,7 @@ typedef struct url_data_s {
 
 void url_read(url_data_t *url_data);
 url_t *url_set(char *str);
+void url_log(url_t *url);
 url_t *url_free(url_t *url);
 void url_cleanup(void);
 url_data_t *url_data_new(void);

--- a/util.c
+++ b/util.c
@@ -1120,6 +1120,9 @@ void util_status_info(int log_it)
   sprintf(buf, "product = \"%s\"", config.product);
   slist_append_str(&sl0, buf);
 
+  sprintf(buf, "release version: %s", config.releasever ?: "unset");
+  slist_append_str(&sl0, buf);
+
   sprintf(buf,
     "memory (MB): total %lld, free %lld (%lld), ramdisk %lld",
     (long long) config.memoryXXX.total >> 20,
@@ -3191,6 +3194,28 @@ void util_set_product_dir(char *prod)
     strprintf(&config.kexec_kernel, "boot/%s/linux", arch);
     strprintf(&config.kexec_initrd, "boot/%s/initrd", arch);
   }
+}
+
+
+/*
+ * Read product version from /usr/lib/os-release.
+ *
+ * The product version is used for replacing $releasever in URLs.
+ */
+void util_get_releasever()
+{
+  file_t *f0, *f;
+
+  f0 = file_read_file("/usr/lib/os-release", kf_none);
+
+  for(f = f0; f; f = f->next) {
+    if(!strcmp(f->key_str, "VERSION_ID")) {
+      str_copy(&config.releasever, f->value);
+      break;
+    }
+  }
+
+  file_free_file(f0);
 }
 
 

--- a/util.h
+++ b/util.h
@@ -82,6 +82,7 @@ void util_update_swap_list(void);
 int util_is_mountable(char *file);
 void util_set_serial_console(char *str);
 void util_set_product_dir(char *prod);
+void util_get_releasever(void);
 
 void scsi_rename(void);
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1171018
- https://trello.com/c/kxbkRRjE

After installation, the user might end up with two repositories: one containing `$releasever`, the other with the replaced value. 

## Solution

linuxrc replaces `$releasever` with the actual product version in URLs. Similar to what libzypp does.

linuxrc does not use `/etc/products.d/baseproduct` to read the version (since that is not available during installation) but uses `/usr/lib/os-release::VERSION_ID`.

linuxrc doc update:
 - https://en.opensuse.org/SDB:Linuxrc#Parameter_Reference

## Implementation notes

This works by keeping a copy of the essential parts of the URL before replacing the zypp variables. The stored values are then used when constructing the zypp URL to pass to yast.

There's no good way to just keep a copy of the full URL as the internally used URL structure gets modified a lot.

To keep the change reasonable, not all URL parts are duplicated. There's not really a use case to
have `$releasever` in the port number, for example.

## See also

- libzypp doc: https://doc.opensuse.org/projects/libzypp/HEAD/zypp-repovars.html
- related card for yast: https://trello.com/c/SPFc3xiZ