### PR TITLE
s390: set rd.zdev=no-auto if auto-config has been turned off (bsc#1168036)

### DIFF
--- a/file.h
+++ b/file.h
@@ -57,7 +57,7 @@ typedef enum {
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
-  key_device_auto_config, key_autoyast_passurl
+  key_device_auto_config, key_autoyast_passurl, key_rd_zdev
 } file_key_t;
 
 typedef enum {

--- a/util.c
+++ b/util.c
@@ -121,8 +121,6 @@ static int cmp_alpha(slist_t *sl0, slist_t *sl1);
 static int cmp_alpha_s(const void *p0, const void *p1);
 static slist_t *get_kernel_list(char *dev);
 
-static int has_device_auto_config(void);
-
 void util_redirect_kmsg()
 {
   static char newvt[2] = { 11, 4 /* console 4 */ };
@@ -5684,7 +5682,7 @@ void util_device_auto_config()
 {
   unsigned do_it = config.device_auto_config;
 
-  if(do_it && !has_device_auto_config()) do_it = 0;
+  if(do_it && !util_has_device_auto_config()) do_it = 0;
 
   if(do_it == 2) {
     int win_old = config.win;
@@ -5700,6 +5698,10 @@ void util_device_auto_config()
     log_info("applying I/O device auto-configuration\n");
     util_run_script("device_auto_config");
     config.device_auto_config_done = 1;
+    config.device_auto_config = 1;
+  }
+  else {
+    config.device_auto_config = 0;
   }
 }
 
@@ -5707,7 +5709,7 @@ void util_device_auto_config()
 /*
  * Check if S390 I/O device auto-config data is available.
  */
-int has_device_auto_config()
+int util_has_device_auto_config()
 {
   FILE *f;
   int has_it = 0;

--- a/util.h
+++ b/util.h
@@ -165,3 +165,4 @@ void util_reparse_blockdev_url(url_t **url_ptr);
 void util_reparse_blockdev_urls(void);
 
 void util_device_auto_config(void);
+int util_has_device_auto_config(void);


### PR DESCRIPTION
## Task

Backport https://github.com/openSUSE/linuxrc/pull/225 to SLE15-SP2.

- https://trello.com/c/qvfNP7rX

## Original Task

- https://bugzilla.suse.com/show_bug.cgi?id=1168036
- https://trello.com/c/if9ZgetC

If the user turns off s390 device auto-config, set also `rd.zdev=no-auto` in the target system.

## Solution

If the system has auto-config data and the user passes `deviceautoconfig=0` or turns off auto-config in a linuxrc dialog,
add `rd.zdev=no-auto` to the boot options.

Also, make linuxrc accept `rd.zdev=no-auto` as alias for `deviceautoconfig=0`.

Note: there is no `rd.zdev=auto` option.

## Links

- https://www.ibm.com/support/knowledgecenter/linuxonibm/com.ibm.linux.z.lkdd/lkdd_c_auto_available.html