### PR TITLE
add rfc2132 keyword to ifcfg option (jsc#SLE-15770, jsc#SLE-15488)

### DIFF
--- a/global.h
+++ b/global.h
@@ -320,6 +320,7 @@ typedef struct ifcfg_s {
   unsigned pattern:1;	///< 'device' is shell glob
   unsigned ptp:1;	///< ptp config, gw is ptp peer
   unsigned search:1;    ///< whether "try" feature is enabled for this ifcfg
+  unsigned rfc2132:1;	///< set DHCLIENT_CREATE_CID=rfc2132
   int netmask_prefix;	///< prefix given via netmask option and only used if an ip doen't have one
   char *vlan;		///< vlan id, if any
   char *ip;		///< list of ip addresses, space separated


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/SLE-15770
- https://trello.com/c/2cxWqhj0

Installer should be able to send DHCP request in RFC2132 format, if needed.

## Solution

Add `rfc2132` option to ifcfg config parameters. For example

```
ifcfg=eth0=dhcp,rfc2132
```

This will create an `ifcfg-eth0` file that looks like this:

```
BOOTPROTO='dhcp'
DHCLIENT_CREATE_CID='rfc2132'
STARTMODE='auto'
```

wicked allows also other values for `DHCLIENT_CREATE_CID`. For these, no shortcut exists. You can specify the option explicitly if needed. For example

```
ifcfg=eth0=dhcp,DHCLIENT_CREATE_CID=rfc4361
```

## See also

- related wicked implementation: https://github.com/openSUSE/wicked/pull/843