### PR TITLE
fix linuxrc module option parsing

### DIFF
--- a/file.h
+++ b/file.h
@@ -61,6 +61,7 @@ typedef enum {
 } file_key_t;
 
 typedef enum {
+  kf_all = -1,
   kf_none = 0,
   kf_cfg = 1 << 0,		/**< /linuxrc.config & /info */
   kf_cmd = 1 << 1,		/**< /proc/cmdline, after info */


### PR DESCRIPTION
## Problem

If linuxrc sees options of the form `foo.bar=xxx` it assumes `bar=xxx` to be a kernel module option for `foo`.

This was broken as linuxrc did this sometimes also when `foo` was a valid linuxrc option.