### PR TITLE
Sw 19

### DIFF
--- a/file.c
+++ b/file.c
@@ -77,6 +77,7 @@ static struct {
   { key_language,       "lang",           kf_cfg + kf_cmd                },
   { key_rebootmsg,      "RebootMsg",      kf_yast                        },
   { key_insmod,         "Insmod",         kf_cfg + kf_cmd1               },
+  { key_insmod_pre,     "InsmodPre",      kf_cfg + kf_cmd0               },
   { key_display,        "Display",        kf_cfg + kf_cmd                },
   { key_ip,             "IP",             kf_none                        },
   { key_netmask,        "Netmask",        kf_cfg + kf_cmd + kf_dhcp      },
@@ -641,6 +642,7 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
     switch(f->key) {
       case key_insmod:
+      case key_insmod_pre:
         file_module_load(f->value);
         break;
 

--- a/file.h
+++ b/file.h
@@ -57,7 +57,7 @@ typedef enum {
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
-  key_device_auto_config, key_autoyast_passurl, key_rd_zdev
+  key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre
 } file_key_t;
 
 typedef enum {
@@ -69,10 +69,11 @@ typedef enum {
   kf_dhcp = 1 << 4,		/**< dhcp info file */
   kf_mem = 1 << 5,		/**< /proc/meminfo */
   kf_boot = 1 << 6,		/**< things the boot loader used */
-  kf_cmd1 = 1 << 7,		/**< between cmd_early and start of hw detection */
+  kf_cmd1 = 1 << 7,		/**< between starting udevd and starting hw detection */
   kf_ibft = 1 << 8,		/**< ibft values (iSCSI BIOS) */
   kf_cont = 1 << 9,		/**< 'content' file */
-  kf_comma = 1 << 10		/**< accept commas as option separator (in command line syntax) */
+  kf_comma = 1 << 10,		/**< accept commas as option separator (in command line syntax) */
+  kf_cmd0 = 1 << 11,		/**< between cmd_early and starting udevd */
 } file_key_flag_t;
 
 typedef struct file_s {

--- a/global.h
+++ b/global.h
@@ -601,6 +601,7 @@ typedef struct {
     driver_t *drivers;		/**< list of extra drive info */
     unsigned disks:1;		/**< automatically ask for module disks */
     slist_t *options;		/**< potential module parameters */
+    unsigned modprobe_ok:1;	/**< if set, using modprobe is possible */
   } module;
 
   struct {			/**< Note: all memory sizes are now in bytes */

--- a/install.c
+++ b/install.c
@@ -474,7 +474,9 @@ int inst_choose_partition(char **partition, int flags, char *txt_menu, char *txt
   char **items3, **values3;
   char *type;
   slist_t *sl;
-  char buf[256], *dev;
+  // buf[] must be able to hold a command (of fixed known length) + filename[256],
+  // so make a bit larger than 256
+  char buf[512], *dev;
   int found = 0, item_mk_part = 0, item_mk_file = 0;
   char *s, *tmp = NULL;
   static char *last_part = NULL;

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -957,6 +957,12 @@ void lxrc_init()
     gm->tm_year + 1900, gm->tm_mon + 1, gm->tm_mday, gm->tm_hour, gm->tm_min, gm->tm_sec
   );
 
+  /*
+   * Do what has to be done before udevd starts; atm this is just the
+   * insmod.pre option.
+   */
+  file_read_info_file("cmdline", kf_cmd0);
+
   if(!config.test) {
     log_show("Starting udev... ");
     util_run_script("udev_setup");

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -854,6 +854,9 @@ void lxrc_init()
     lxrc_add_parts();
   }
 
+  // modprobe config files exist from here on
+  config.module.modprobe_ok = 1;
+
   config.platform_name=get_platform_name();
 
   LXRC_WAIT

--- a/module.c
+++ b/module.c
@@ -697,7 +697,7 @@ int mod_insmod(char *module, char *param)
    * been initialized, use modprobe instead of insmod as module deps are not
    * yet known to linuxrc.
    */
-  unsigned use_modprobe = config.module.list ? 0 : 1;
+  unsigned use_modprobe = config.module.modprobe_ok && (config.module.list ? 0 : 1);
 
   buf_len = sprintf(buf, "%s %s",
     use_modprobe ? "modprobe" : "insmod",

--- a/module.c
+++ b/module.c
@@ -692,10 +692,20 @@ int mod_insmod(char *module, char *param)
 
   if(mod_is_loaded(module)) return 0;
 
-  buf_len = sprintf(buf, "insmod %s", config.forceinsmod ? "-f " : "");
+  /*
+   * When loading a module before linuxrc's module loading framework has
+   * been initialized, use modprobe instead of insmod as module deps are not
+   * yet known to linuxrc.
+   */
+  unsigned use_modprobe = config.module.list ? 0 : 1;
 
-  if (util_check_exist(module)) {
-    /* wow, user provided a _path_ */
+  buf_len = sprintf(buf, "%s %s",
+    use_modprobe ? "modprobe" : "insmod",
+    config.forceinsmod ? "-f " : ""
+  );
+
+  /* insmod expects a full path as argument, modprobe not */
+  if (use_modprobe || util_check_exist(module)) {
     strcpy(buf + buf_len, module);
   } else {
     if(!mod_find_module(config.module.dir, module, buf + buf_len))


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/231 to SLE15-SP2.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1174912
- https://trello.com/c/odtwPIg0

Add `insmod.pre` option to linuxrc.

The purpose if this option is to give the user an opportunity to load modules before udevd is started. The existing `insmod` option runs too late for that.