### PR TITLE
do not offer --real-mode as kexec option in debug mode  (bsc#1141875)

### DIFF
--- a/util.c
+++ b/util.c
@@ -5284,15 +5284,9 @@ void util_boot_system()
     kernel_name, initrd_name, kernel_options
   );
 
-  char *buf1 = NULL;
-
-  // on x86, non-uefi use real-mode interface;
-  // this seems to work better
-  if(strstr(kernel_name, "vmlinuz-") && !config.efi_vars) {
-    str_copy(&buf1, "--real-mode");
-  }
-
   if(config.debug) {
+    char *buf1 = NULL;
+
     if(dia_input2("Enter additional kexec options", &buf1, 57, 0)) {
       util_umount("/mnt");
 
@@ -5303,10 +5297,12 @@ void util_boot_system()
 
       return;
     }
-    if(buf1) strprintf(&buf, "%s %s", buf, buf1);
-  }
 
-  str_copy(&buf1, NULL);
+    if(buf1) {
+      strprintf(&buf, "%s %s", buf, buf1);
+      str_copy(&buf1, NULL);
+    }
+  }
 
   if(!config.test) {
     int err = lxrc_run(buf);


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1141875

In debug mode, linuxrc defaults to adding `--real-mode` as option to kexec. That's a very old option and rather strange in modern times.

## Solution

Remove it.