### PR TITLE
Since kernel 5.10, /sys/firmware/efi/vars has been dropped

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1078,7 +1078,7 @@ void lxrc_init()
   if(config.had_segv) config.manual = 1;
 
   /* check efi status */
-  if(util_check_exist("/sys/firmware/efi/vars") == 'd') {
+  if(util_check_exist("/sys/firmware/efi/vars") == 'd' || util_check_exist("/sys/firmware/efi/efivars") == 'd') {
     config.efi_vars = 1;
   }
   log_debug("efi = %d\n", config.efi_vars);


### PR DESCRIPTION
for non-x86 architectures, only /sys/firmware/efi/efivars remains
So, check both to know if we are running on EFI boo#1180408