### PR TITLE
support using zram device as root file system (jsc#PM-2253)

### DIFF
--- a/file.c
+++ b/file.c
@@ -320,6 +320,9 @@ static struct {
   { key_auto_assembly,  "AutoAssembly",   kf_cfg + kf_cmd_early          },
   { key_device_auto_config, "DeviceAutoConfig",  kf_cfg + kf_cmd_early   },
   { key_rd_zdev,        "rd.zdev",        kf_cfg + kf_cmd_early          },
+  { key_zram,           "zram",           kf_cmd_early                   },
+  { key_zram_root,      "zram_root",      kf_cmd_early                   },
+  { key_zram_swap,      "zram_swap",      kf_cmd_early                   },
 };
 
 static struct {
@@ -1854,6 +1857,27 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         }
         break;
 
+      case key_zram:
+        if(f->is.numeric) {
+          if(f->nvalue) {
+            str_copy(&config.zram.root_size, "1G");
+            str_copy(&config.zram.swap_size, "1G");
+          }
+          else {
+            str_copy(&config.zram.root_size, NULL);
+            str_copy(&config.zram.swap_size, NULL);
+          }
+        }
+        break;
+
+      case key_zram_root:
+        str_copy(&config.zram.root_size, *f->value ? f->value : NULL);
+        break;
+
+      case key_zram_swap:
+        str_copy(&config.zram.swap_size, *f->value ? f->value : NULL);
+        break;
+
       default:
         break;
     }
@@ -2026,6 +2050,7 @@ void file_write_install_inf(char *dir)
   file_write_num(f, key_kexec_reboot, config.kexec_reboot);
   file_write_num(f, key_efi, config.efi >= 0 ? config.efi : config.efi_vars);
   file_write_num(f, key_insecure, !config.secure);
+  file_write_str(f, key_zram_swap, config.zram.swap_size);
   if(config.upgrade) file_write_num(f, key_upgrade, config.upgrade);
   if(config.media_upgrade) file_write_num(f, key_media_upgrade, config.media_upgrade);
   if(config.self_update_url) {

--- a/file.h
+++ b/file.h
@@ -57,7 +57,8 @@ typedef enum {
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
-  key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre
+  key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
+  key_zram, key_zram_root, key_zram_swap
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -461,6 +461,10 @@ typedef struct {
   unsigned device_auto_config:2;	/**< run s390 device auto-config (cf. bsc#1168036) */
   unsigned device_auto_config_done:1;	/**< set after s390 device auto-config has been run */
   struct {
+    char *root_size;		/**< zram root fs size (e.g. "1G" or "512M") */
+    char *swap_size;		/**< zram swap size (e.g. "1G" or "512M") */
+  } zram;
+  struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */
     char *type;			/**< braille driver */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -135,6 +135,10 @@ int main(int argc, char **argv, char **env)
   config.run_as_linuxrc = 1;
   config.tmpfs = 1;
 
+  // use zram
+  str_copy(&config.zram.root_size, "1G");
+  str_copy(&config.zram.swap_size, "1G");
+
   str_copy(&config.console, "/dev/console");
 
   // define logging destinations for the various log levels:

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -200,6 +200,9 @@ int main(int argc, char **argv, char **env)
       file_do_info(file_get_cmdline(key_linuxrcstderr), kf_cmd + kf_cmd_early);
       file_do_info(file_get_cmdline(key_lxrcdebug), kf_cmd + kf_cmd_early);
       file_do_info(file_get_cmdline(key_linuxrc_core), kf_cmd + kf_cmd_early);
+      file_do_info(file_get_cmdline(key_zram), kf_cmd_early);
+      file_do_info(file_get_cmdline(key_zram_root), kf_cmd_early);
+      file_do_info(file_get_cmdline(key_zram_swap), kf_cmd_early);
       util_setup_coredumps();
       util_free_mem();
       umount("/proc");
@@ -433,14 +436,38 @@ void lxrc_movetotmpfs()
   int i;
   char *newroot = "/.newroot";
 
-  log_info("Moving into tmpfs...");
+  log_info("Moving into %s...", config.zram.root_size ? "zram" : "tmpfs");
+
   i = mkdir(newroot, 0755);
   if(i) {
     perror(newroot);
     return;
   }
 
-  i = mount("tmpfs", newroot, "tmpfs", 0, "size=100%,nr_inodes=0");
+  if(config.zram.root_size) {
+    mount("proc", "/proc", "proc", 0, 0);
+    mount("sysfs", "/sys", "sysfs", 0, 0);
+    mount("devtmpfs", "/dev", "devtmpfs", 0, 0);
+    char *buf = NULL;
+    strprintf(&buf, "/scripts/zram_setup %s", config.zram.root_size);
+    i = system(buf);
+    free(buf);
+    if(!i) {
+      i = util_mount_rw("/dev/zram0", newroot, NULL);
+    }
+    umount("/dev");
+    umount("/sys");
+    umount("/proc");
+    if(i) log_info("zram setup failed, falling back to tmpfs...");
+  }
+  else {
+    i = 1;
+  }
+
+  if(i) {
+    i = mount("tmpfs", newroot, "tmpfs", 0, "size=100%,nr_inodes=0");
+  }
+
   if(i) {
     perror(newroot);
     return;

--- a/linuxrc_yast_interface.txt
+++ b/linuxrc_yast_interface.txt
@@ -329,6 +329,14 @@ Insecure: 0|1
 # entry is missing if no xvideo option was used
 XVideo: %s
 
+# the yast setup script (/sbin/inst_setup) uses this entry to set up (and
+# enable) a zram swap device
+#
+# the value is the disk size that is passed to /sys/block/zramN/disksize
+#
+# entry is missing if unset
+zram_swap: %s
+
 *** Note ***
 
  There may be some more entries in install.inf but they are put there by

--- a/util.c
+++ b/util.c
@@ -1151,6 +1151,13 @@ void util_status_info(int log_it)
   slist_append_str(&sl0, buf);
 
   sprintf(buf,
+    "zram: root size \"%s\", swap size \"%s\"",
+    config.zram.root_size ?: "",
+    config.zram.swap_size ?: ""
+  );
+  slist_append_str(&sl0, buf);
+
+  sprintf(buf,
     "InstsysID: %s%s",
     config.instsys_id ?: "unset",
     config.instsys_complain ? config.instsys_complain == 1 ? " (check)" : " (block)" : ""


### PR DESCRIPTION
## Task

Allow moving the root file system into a zram device and/or enable swapping to a zram device.

- https://jira.suse.com/browse/PM-2253
- https://trello.com/c/DawiPzcU

## Usage

Use these boot options:

- `zram.root=SIZE`: move root fs into a zram device of size `SIZE`
- `zram.swap=SIZE`: before starting YaST, enable swapping to a zram device of size `SIZE`
- `zram=1`: a shorthand for `zram.root=1G zram.swap=1G` (this is the default)
- `zram=0`: disable zram use

`SIZE` is something like `512M` or `1G`.

## See also

- adjusted installation-images package: https://github.com/openSUSE/installation-images/pull/462
- zram documentation: https://www.kernel.org/doc/html/latest/admin-guide/blockdev/zram.html

## Notes

- the changes do not affect the non-zram workflow
- the zram root fs device is formatted as ext2
- zstd compression is used
- swap is not handled in linuxrc, the setting is passed on as `zram_swap: SIZE` in `/etc/install.inf`

## Results

- SLE15-SP3 can be installed with 512 MiB main memory
- TW can be installed with 600 MiB 
- TW **might** be installable even with 512 MiB, but kernel already fails unpacking the initrd at that memory size
- overall stability and performance under low memory conditions is much improved
- overcommitment (1 GiB root fs + 1 GiB swap with 512 MiB actual RAM) causes no noticable issues

## Testing

Here are some stats trying different file systems. ext2 seems most sensible, xfs looks also ok - the tooling overhead is just slightly bigger compared to ext2.

- the initial root file system size on Tumbleweed is 325 MiB, with 274 MiB memory usage by zram

The file system stats are done just before YaST is started.

The 3rd column in `mm_stat` is the current zram device memory usage in bytes.

```
= Tumbleweed root fs size =

- 245811 kiB squashfs compressed images + X

== btrfs ==

console:install:/ # cat /sys/block/zram0/mm_stat
1073741824 288515048 290676736        0 290676736   179742        0    62566
console:install:/ # df /
Filesystem     1K-blocks   Used Available Use% Mounted on
/dev/zram0       1048576 326348    614644  35% /

== ext2 ==

console:install:/ # cat /sys/block/zram0/mm_stat
1073741824 285482598 287576064        0 287576064   179005        0    62382
console:install:/ # df /
Filesystem     1K-blocks   Used Available Use% Mounted on
/dev/zram0       1032088 331476    648184  34% /

== ext4 ==

console:install:/ # cat /sys/block/zram0/mm_stat
1073741824 286295536 288505856        0 288505856   174631        0    62382
console:install:/ # df /
Filesystem     1K-blocks   Used Available Use% Mounted on
/dev/zram0        999320 331832    598676  36% /

== xfs ==

console:install:/ # cat /sys/block/zram0/mm_stat
1073741824 286335197 288489472        0 288493568   180495        0    62392
console:install:/ # df /
Filesystem     1K-blocks   Used Available Use% Mounted on
/dev/zram0       1038336 356176    682160  35% /
```
