### PR TITLE
fix buffer overflow when setting up loop device (bsc#1180161)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -274,7 +274,7 @@ void auto2_scan_hardware()
       if(hd->bus.id == bus_usb) ju++;
       di = hd->driver_info;
       if(di && di->any.type == di_kbd) {
-        if(di->kbd.XkbModel) strcpy(xkbmodel_tg, di->kbd.XkbModel);
+        if(di->kbd.XkbModel) strncpy(xkbmodel_tg, di->kbd.XkbModel, sizeof xkbmodel_tg - 1);
         if(di->kbd.keymap) {
           str_copy(&config.keymap, di->kbd.keymap);
         }

--- a/util.c
+++ b/util.c
@@ -2786,7 +2786,7 @@ char *util_attach_loop(char *file, int ro)
     sprintf(buf, "/dev/loop%d", i);
     if((device = open(buf, (ro ? O_RDONLY : O_RDWR) | O_LARGEFILE)) >= 0) {
       memset(&loopinfo, 0, sizeof loopinfo);
-      strcpy(loopinfo.lo_name, file);
+      strncpy(loopinfo.lo_name, file, sizeof loopinfo.lo_name - 1);
       rc = ioctl(device, LOOP_SET_FD, fd);
       if(rc != -1) rc = ioctl(device, LOOP_SET_STATUS, &loopinfo);
       close(device);


### PR DESCRIPTION
## Task

Backport https://github.com/openSUSE/linuxrc/pull/247 to SLE15-SP2.

## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1180161
- https://trello.com/c/0zqcWVhD

When linuxrc needs to set up a loop device it crashes if the file name is a bit longish (>= 64 chars).

This happens because the kernel's `loop_info` struct has a file name field `char lo_name[LO_NAME_SIZE]` with `LO_NAME_SIZE = 64`.

## Solution

Use `strncpy`.

## Bonus

Check remaining `strcpy` uses.