### PR TITLE
Revert "default to using zram"

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -135,10 +135,6 @@ int main(int argc, char **argv, char **env)
   config.run_as_linuxrc = 1;
   config.tmpfs = 1;
 
-  // use zram
-  str_copy(&config.zram.root_size, "1G");
-  str_copy(&config.zram.swap_size, "1G");
-
   str_copy(&config.console, "/dev/console");
 
   // define logging destinations for the various log levels:


### PR DESCRIPTION
## Task

After some discussion in https://jira.suse.com/browse/PM-2253, the zram feature will be accepted into sle15-sp3 if it is disabled by default.

We will change the default for Tumbleweed to 'enabled' later.