### PR TITLE
add 'extend' option (bsc#1183368)

### DIFF
--- a/file.c
+++ b/file.c
@@ -323,6 +323,7 @@ static struct {
   { key_zram,           "zram",           kf_cmd_early                   },
   { key_zram_root,      "zram_root",      kf_cmd_early                   },
   { key_zram_swap,      "zram_swap",      kf_cmd_early                   },
+  { key_extend,         "Extend",         kf_cfg + kf_cmd                },
 };
 
 static struct {
@@ -1876,6 +1877,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_zram_swap:
         str_copy(&config.zram.swap_size, *f->value ? f->value : NULL);
+        break;
+
+      case key_extend:
+        slist_assign_values(&config.extend_option, f->value);
         break;
 
       default:

--- a/file.h
+++ b/file.h
@@ -58,7 +58,7 @@ typedef enum {
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
   key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
-  key_zram, key_zram_root, key_zram_swap
+  key_zram, key_zram_root, key_zram_swap, key_extend
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -544,6 +544,7 @@ typedef struct {
                                  * 3: if necessary, no user dialog
                                  */
   char *platform_name;           /* Human-readable name of the hardware */
+  slist_t *extend_option;	/**< list of instsys extensions given via 'extend' boot option */
 
   struct {
     unsigned failed:1;		/**< digest check failed */

--- a/url.c
+++ b/url.c
@@ -3269,6 +3269,11 @@ void url_build_instsys_list(char *image, int read_list)
     }
   }
 
+  // if user specified extra parts to add via 'extend' option, add them here
+  for(sl = config.extend_option; sl; sl = sl->next) {
+    slist_append_str(&config.url.instsys_list, sl->key);
+  }
+
   for(sl = config.url.instsys_list; sl; sl = sl->next) {
     s = sl->key;
     if(*s == '?') s++;

--- a/util.c
+++ b/util.c
@@ -1520,6 +1520,16 @@ void util_status_info(int log_it)
   sprintf(buf, "rescueimage = \"%s\"", config.rescueimage);
   slist_append_str(&sl0, buf);
 
+  if(config.extend_option) {
+    strcpy(buf, "extend option:");
+    slist_append_str(&sl0, buf);
+    for(sl = config.extend_option; sl; sl = sl->next) {
+      if(!sl->key) continue;
+      sprintf(buf, "  %s", sl->key);
+      slist_append_str(&sl0, buf);
+    }
+  }
+
   sprintf(buf, "setup command = \"%s\"", config.setupcmd);
   slist_append_str(&sl0, buf);
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1183368
- https://github.com/yast/yast-installation/issues/925

Add `extend` option to linuxrc to be able to load additional inst-sys parts. An inst-sys part is any file that is available on the installation medium in the `/boot/ARCH` directory.

The argument is a comma (',') separated list. If a part is preceded with a '?' it marks this part as optional (linuxrc will not abort the installation if it is missing).

## Usage examples

- load `foo` and `bar` extensions

```
extend=foo,bar
```

- load `foo` and (optionally, if it exists) `bar`
```
extend=foo,?bar
```

Note that several `extend` options override each other. So don't do `extend=foo extend=bar`, rather do `extend=foo extend=+bar` if really necessary.