### PR TITLE
fix handling of modules in driver updates (bsc#1184550)

### DIFF
--- a/module.c
+++ b/module.c
@@ -42,13 +42,9 @@
 
 #define MOD_EXT(mod)	{ .ext = (mod), .len = sizeof(mod) - 1 }
 
-typedef struct {
-  char *ext;
-  size_t len;
-} mod_extensions_t;
-
 // list of recognized module file name extensions
-static const mod_extensions_t mod_extensions[] = {
+// list ends with an empty entry
+const mod_extensions_t mod_extensions[] = {
   MOD_EXT(".ko.xz"),
   MOD_EXT(".ko"),
   { }

--- a/module.h
+++ b/module.h
@@ -6,6 +6,14 @@
  *
  */
 
+typedef struct {
+  char *ext;
+  size_t len;
+} mod_extensions_t;
+
+// array of possible module extensions
+extern const mod_extensions_t mod_extensions[];
+
 int        mod_get_type(char *type_name);
 int        mod_check_modules(char *type_name);
 void       mod_init(int autoload);


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184550
- https://trello.com/c/iroG0VHx

Kernel modules in driver updates are not handled correctly. Due to the `*.ko` to `*.ko.xz` extension change.

## Solution

Be more careful and anticipate either variant in driver updates.