### PR TITLE
don't ask for ssh password if ssh.password.enc is set (bsc#1185304)

### DIFF
--- a/net.c
+++ b/net.c
@@ -96,7 +96,7 @@ void net_ask_password()
     }
   }
 
-  if(config.usessh && !config.net.sshpassword && !config.net.sshkey) {
+  if(config.usessh && !(config.net.sshpassword || config.net.sshpassword_enc || config.net.sshkey)) {
     if(!config.win) util_disp_init();
     dia_input2("Enter your temporary SSH password.", &config.net.sshpassword, 20, 1);
   }


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/260 to sle12-sp5.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1185304
- https://trello.com/c/2yMZcrbI

Even if `ssh.password.enc` is set, linuxrc asks for a password.