### PR TITLE
prevent memory corruption while iterating through network device list (bsc#1187014)

### DIFF
--- a/global.h
+++ b/global.h
@@ -448,6 +448,7 @@ typedef struct {
   unsigned repomd:1;		/**< install repo is repo-md */
   unsigned norepo:1;            /**< disable repo location check, expect YaST */
   unsigned auto_assembly:1;	/**< enable MD/RAID auto-assembly */
+  unsigned lock_device_list;	/**< prevent device list updates if != 0 */
   struct {
     unsigned check:1;		/**< check for braille displays and start brld if found */
     char *dev;			/**< braille device */

--- a/url.c
+++ b/url.c
@@ -1477,6 +1477,8 @@ int url_mount(url_t *url, char *dir, int (*test_func)(url_t *))
   url_device = url->device;
   if(!url_device) url_device = url->is.network ? config.ifcfg.manual->device : config.device;
 
+  config.lock_device_list++;
+
   for(found = 0, hd = sort_a_bit(fix_device_names(hd_list2(config.hd_data, hw_items, 0))); hd; hd = hd->next) {
     for(hwaddr = NULL, res = hd->res; res; res = res->next) {
       if(res->any.type == res_hwaddr) {
@@ -1527,6 +1529,8 @@ int url_mount(url_t *url, char *dir, int (*test_func)(url_t *))
       err = 1;
     }
   }
+
+  config.lock_device_list--;
 
   if(!found) {
     log_info("device not found (err = %d): %s\n", err, url_device ?: "");
@@ -2099,6 +2103,8 @@ int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *la
   if(config.hd_data) {
     url_device = url->device ?: config.ifcfg.manual->device;
 
+    config.lock_device_list++;
+
     for(found = 0, hd = sort_a_bit(hd_list2(config.hd_data, hw_items, 0)); hd; hd = hd->next) {
       for(hwaddr = NULL, res = hd->res; res; res = res->next) {
         if(res->any.type == res_hwaddr) {
@@ -2132,6 +2138,8 @@ int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *la
       }
       if(config.sig_failed || config.digests.failed) break;
     }
+
+    config.lock_device_list--;
 
     if(!found) {
       str_copy(&url->used.device, NULL);

--- a/util.c
+++ b/util.c
@@ -3908,6 +3908,8 @@ uint64_t blk_size(char *dev)
 
 /*
  * Update device list in config.hd_data (if udev got new events).
+ *
+ * Do nothing if config.lock_device_list is != 0.
  */
 void update_device_list(int force)
 {
@@ -3932,6 +3934,11 @@ void update_device_list(int force)
   }
 
   if(!force) return;
+
+  if(config.lock_device_list) {
+    log_info("device list locked - no update\n");
+    return;
+  }
 
   log_info("%sscanning devices\n", config.hd_data ? "re" : "");
 


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/264 to SLE15-SP1.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1187014
- https://trello.com/c/IbMHDdRx

If a network URL passed to linuxrc is not valid, linuxrc will iterate trough all available network interfaces trying them in turn to read the data. During this iteration, a memory corruption may happen.

## Background

linuxrc holds all hardware probing data in `config.hd_data` and the iteration goes over a linked list anchored there.

During the iteration linuxrc may implicitly trigger an `update_device_list` function which will update the hardware data in `config.hd_data` - but only if udev events have been processed since the last call to `update_device_list`.

Unfortunately, udev events are not only generated by new hardware during this period - and if this happens, it completely breaks the iteration loop.

## Solution

Introduce a locking mechanism blocking updates of `config.hd_data` if needed (i.e. during the loop).