### PR TITLE
read rules.xml if autoyast option indicates a rules-based setup (bsc#1187235)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -1202,9 +1202,13 @@ int auto2_remove_extension(char *extension)
 /*
  * Read autoyast file from url and parse it.
  *
- * If the autoyast url points to a directory, nothing is read but the
- * function tries to mount the directory to ensure it exists. This is
- * basically done to search for the correct medium.
+ * If the autoyast url points to a directory, the function tries to mount
+ * the directory to ensure it exists. If it is a non-mountable url (e.g.
+ * http) it assumes a rules-based setup and that a file rules/rules.xml
+ * exists below the specified directory. The rules file is only read, not
+ * parsed.
+ *
+ * This is basically done to search for the correct medium.
  */
 void auto2_read_autoyast(url_t *url)
 {
@@ -1219,7 +1223,7 @@ void auto2_read_autoyast(url_t *url)
    *
    * That works for mountable url schemes.
    *
-   * For the rest (http(s), (t)ftp) we'll just assume it works.
+   * For the rest (http(s), (t)ftp), try to read rules/rules.xml.
    */
   if(url->is.dir) {
     /*
@@ -1230,6 +1234,22 @@ void auto2_read_autoyast(url_t *url)
     if(url->is.mountable) {
       url_mount(url, NULL, NULL);
       url_umount(url);
+    }
+    else if(url->path) {
+      char *old_path = NULL;
+      str_copy(&old_path, url->path);
+
+      int path_len = strlen(url->path);
+      if(path_len && url->path[path_len - 1] == '/') url->path[path_len - 1] = 0;
+
+      strprintf(&url->path, "%s/rules/rules.xml", url->path);
+
+      log_show_maybe(!url->quiet, "Downloading AutoYaST rules file: %s\n", url->str);
+
+      url_read_file_anywhere(url, NULL, NULL, "/download/rules.xml", NULL, URL_FLAG_PROGRESS + URL_FLAG_NODIGEST);
+
+      str_copy(&url->path, old_path);
+      free(old_path);
     }
 
     return;


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1187235
- https://trello.com/c/jRFPOOAW

If linuxrc is passed an `autoyast` option for a rules-based setup, e.g. `autoyast=http://example.com/bar/profiles/` it cannot retrieve that url to test the network connection - because it's a directory.

This leads to the situation that linuxrc may skip the network setup (it doesn't need it in this case).

## Solution

Assume that a file `rules/rules.xml` exists below the specified directory and try to retrieve that instead. linuxrc does not parse the file, it is only read to ensure the network connection is working.

## Note

It is also possible to pass a directory to the `autoyast` option with the intention to select the profile based on the ip or mac address. See the [autoyast doc](https://doc.opensuse.org/projects/autoyast/#Commandline-ay). This is different from the rules-based scenario discussed above. This case is not handled and the user has to setup the network explicitly.