### PR TITLE
Add support for gz and zst compressed modules

### DIFF
--- a/module.c
+++ b/module.c
@@ -46,6 +46,8 @@
 // list ends with an empty entry
 const mod_extensions_t mod_extensions[] = {
   MOD_EXT(".ko.xz"),
+  MOD_EXT(".ko.gz"),
+  MOD_EXT(".ko.zst"),
   MOD_EXT(".ko"),
   { }
 };


### PR DESCRIPTION
Add .ko.gz and .ko.zst to the mod_extensions array. Thanks for
having coded this with future extension in mind!