### PR TITLE
s390x: ask for the VLAN id by default (jsc#SLE-18631, jsc#SLE-19610)

### DIFF
--- a/global.h
+++ b/global.h
@@ -365,7 +365,7 @@ typedef struct {
 #define NS_NOW			(1 << 9)
 
 #if defined(__s390__) || defined(__s390x__)
-#define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER | NS_DISPLAY)
+#define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER | NS_DISPLAY | NS_VLANID)
 #else
 #define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER)
 #endif


### PR DESCRIPTION
- https://trello.com/c/BV5JkVBk
- dev: https://jira.suse.com/browse/SLE-19610
- epic: https://jira.suse.com/browse/SLE-18631

Until now you'd have to specify netsetup=vlanid to get it.

From the epic: "Based on our experience with customers the large majority has VLAN segmented networks. If we can have this option available by default it might prevent some frustration for customers not 100% familiar with the SLES specifics."

Documented at <https://en.opensuse.org/SDB:Linuxrc#p_netsetup>