### PR TITLE
default to using zram (bsc#1191203, #bsc1189707)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -135,6 +135,10 @@ int main(int argc, char **argv, char **env)
   config.run_as_linuxrc = 1;
   config.tmpfs = 1;
 
+  // use zram
+  str_copy(&config.zram.root_size, "1G");
+  str_copy(&config.zram.swap_size, "1G");
+
   str_copy(&config.console, "/dev/console");
 
   // define logging destinations for the various log levels:


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1189707
- https://bugzilla.suse.com/show_bug.cgi?id=1191203

Use zram during installation.

This was already implemented for SP3 but not made the default. To avoid further memory shortage related issues, make zram usage the default in SP4.