### PR TITLE
Add support for gz and zst compressed modules (jsc#SLE-21256, bsc#1192855)

### DIFF
--- a/module.c
+++ b/module.c
@@ -46,6 +46,8 @@
 // list ends with an empty entry
 const mod_extensions_t mod_extensions[] = {
   MOD_EXT(".ko.xz"),
+  MOD_EXT(".ko.gz"),
+  MOD_EXT(".ko.zst"),
   MOD_EXT(".ko"),
   { }
 };


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1192855
- https://jira.suse.com/browse/SLE-21256

Port https://github.com/openSUSE/linuxrc/pull/273 to sle15-sp4.

## Original Task

Kernel moves to zstd compression for modules and initrd. Add .ko.gz and .ko.zst to the mod_extensions array.