### PR TITLE
enable display dialog for all architectures

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -97,9 +97,10 @@ struct {
   { di_extras_quit,      "Quit linuxrc"         },
   
   { di_display_vnc,    	 "VNC"	          },
-  { di_display_x11,  	 "X11"	          },
+  { di_display_x11,  	 "Remote X11"	          },
   { di_display_ssh,      "SSH"	          },
-  { di_display_console,  "ASCII Console"	  },
+  { di_display_console,  "Text-based UI"	  },
+  { di_display_qt,       "Graphical UI"	  },
   
   { di_390net_osa,	 "OSA-2 or OSA Express"           },
   { di_390net_ctc,	 "Channel To Channel (CTC)"	          },

--- a/dialog.h
+++ b/dialog.h
@@ -80,6 +80,7 @@ typedef enum {
   di_display_vnc,
   di_display_ssh,
   di_display_console,
+  di_display_qt,
 
   di_390net_osa,
   di_390net_ctc,

--- a/file.c
+++ b/file.c
@@ -95,7 +95,7 @@ static struct {
   { key_rebootwait,     "WaitReboot",     kf_cfg + kf_cmd                },	/* drop it? */
   { key_sourcemounted,  "Sourcemounted",  kf_none                        },
   { key_cdrom,          "Cdrom",          kf_none                        },
-  { key_console,        "Console",        kf_none                        },
+  { key_console,        "Console",        kf_cmd0                        },
   { key_ptphost,        "Pointopoint",    kf_cfg + kf_cmd                },
   { key_domain,         "Domain",         kf_cfg + kf_cmd + kf_dhcp      },
   { key_domain,         "DNSDOMAIN",      kf_cfg + kf_cmd + kf_dhcp      },
@@ -325,6 +325,7 @@ static struct {
   { key_zram_root,      "zram_root",      kf_cmd_early                   },
   { key_zram_swap,      "zram_swap",      kf_cmd_early                   },
   { key_extend,         "Extend",         kf_cfg + kf_cmd                },
+  { key_switch_to_fb,   "SwitchToFB",     kf_cfg + kf_cmd_early          },
 };
 
 static struct {
@@ -1016,6 +1017,11 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_noshell:
         if(f->is.numeric) config.noshell = f->nvalue;
+        break;
+
+      case key_console:
+        // just remember that it was used
+        config.console_option = 1;
         break;
 
       case key_consoledevice:
@@ -1886,6 +1892,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_extend:
         slist_assign_values(&config.extend_option, f->value);
+        break;
+
+      case key_switch_to_fb:
+        if(f->is.numeric) config.switch_to_fb = f->nvalue;
         break;
 
       default:

--- a/file.c
+++ b/file.c
@@ -1206,9 +1206,7 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
             else if(!strcmp(s, "hostip")) i = NS_HOSTIP;
             else if(!strcmp(s, "vlanid")) i = NS_VLANID;
             else if(!strcmp(s, "gateway")) i = NS_GATEWAY;
-#if defined(__s390__) || defined(__s390x__)
             else if(!strcmp(s, "display")) i = NS_DISPLAY;
-#endif
             else if(!strcmp(s, "now")) i = NS_NOW;
             else if(!strcmp(s, "all")) do_all = 1;
             else if(!strncmp(s, "nameserver", sizeof "nameserver" - 1)) {

--- a/file.h
+++ b/file.h
@@ -58,7 +58,7 @@ typedef enum {
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
   key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
-  key_zram, key_zram_root, key_zram_swap, key_extend
+  key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -461,6 +461,7 @@ typedef struct {
   unsigned device_auto_config:2;	/**< run s390 device auto-config (cf. bsc#1168036) */
   unsigned device_auto_config_done:1;	/**< set after s390 device auto-config has been run */
   unsigned lock_device_list;	/**< prevent device list updates if != 0 */
+  unsigned switch_to_fb:2;	/**< switch to framebuffer device; 0: no, 1: auto, 2: always */
   struct {
     char *root_size;		/**< zram root fs size (e.g. "1G" or "512M") */
     char *swap_size;		/**< zram swap size (e.g. "1G" or "512M") */
@@ -503,6 +504,7 @@ typedef struct {
   char **argv;			/**< store argv here */
   uint64_t segv_addr;		/**< segfault addr if last linuxrc run */
   char *console;		/**< console device */
+  unsigned console_option:1;	/**< whether 'console' kernel boot option was used */
   char *serial;			/**< serial console parameters, e.g. ttyS0,38400 or ttyS1,9600n8 */
   char *product;		/**< product name */
   char *product_dir;		/**< product specific dir component (e.g. 'suse') */

--- a/install.c
+++ b/install.c
@@ -1427,6 +1427,11 @@ int inst_execute_yast()
       else {
         signal(SIGUSR1, SIG_IGN);
 
+        // stdout = stderr
+        dup2(1, 2);
+        // close other file descriptors
+        for(int fd = 3; fd < 10; fd++) close(fd);
+
         // log_info("%d: system()\n", getpid());
         err = system(setupcmd);
         // log_info("%d: exit(%d)\n", getpid(), err);

--- a/install.c
+++ b/install.c
@@ -311,10 +311,11 @@ int inst_choose_display()
   else {
     dia_item_t di;
     dia_item_t items[] = {
-      di_display_x11,
+      di_display_qt,
+      di_display_console,
       di_display_vnc,
       di_display_ssh,
-      di_display_console,
+      di_display_x11,
       di_none
     };
 
@@ -327,39 +328,53 @@ int inst_choose_display()
 
 /*
  * return values:
- * -1    : abort (aka ESC)
  *  0    : ok
  *  other: stay in menu
  */
 int inst_choose_display_cb(dia_item_t di)
 {
+  int result = 0;
+
   di_inst_choose_display_last = di;
 
   switch(di) {
     case di_display_x11:
-      if(dia_input2("Enter the name of the host running the X11 server.", &config.net.displayip, 40, 0)) return -1;
+      dia_input2("Enter the name of the host running the X11 server.", &config.net.displayip, 40, 0);
+      if(!config.net.displayip) result = 1;
       break;
 
     case di_display_vnc:
-      config.vnc=1;
+      config.vnc = 1;
       net_ask_password();
+      if(!config.net.vncpassword) {
+        config.vnc = 0;
+        result = 1;
+      }
       break;
 
     case di_display_ssh:
-      config.usessh=1;
-      config.vnc=0;
+      config.usessh = 1;
+      config.vnc = 0;
       net_ask_password();
+      if(!(config.net.sshpassword || config.net.sshpassword_enc)) {
+        config.usessh = 0;
+        result = 1;
+      }
       break;
 
     case di_display_console:
-      /* nothing to do */
+      config.textmode = 1;
+      break;
+
+    case di_display_qt:
+      config.textmode = 0;
       break;
 
     default:
       break;
   }
 
-  return 0;
+  return result;
 }
 
 

--- a/install.c
+++ b/install.c
@@ -69,10 +69,8 @@ static int   inst_execute_yast        (void);
 static int   inst_commit_install      (void);
 static int   inst_choose_netsource    (void);
 static int   inst_choose_netsource_cb (dia_item_t di);
-#if defined(__s390__) || defined(__s390x__)
 static int   inst_choose_display      (void);
 static int   inst_choose_display_cb   (dia_item_t di);
-#endif
 static int   inst_choose_source       (void);
 static int   inst_choose_source_cb    (dia_item_t di);
 static int   inst_menu_cb             (dia_item_t di);
@@ -81,9 +79,7 @@ static int choose_dud(char **dev);
 static dia_item_t di_inst_menu_last = di_none;
 static dia_item_t di_inst_choose_source_last = di_none;
 static dia_item_t di_inst_choose_netsource_last = di_none;
-#if defined(__s390__) || defined(__s390x__)  
 static dia_item_t di_inst_choose_display_last = di_none;
-#endif
 
 static int ask_for_swap(int64_t size, char *msg);
 
@@ -298,7 +294,14 @@ int inst_choose_netsource_cb(dia_item_t di)
   return err ? 1 : 0;
 }
 
-#if defined(__s390__) || defined(__s390x__)  
+
+/*
+ * Menu: installer UI variant
+ *
+ * return values:
+ *   0 : ok
+ *   1 : error
+ */
 int inst_choose_display()
 {
   if(!config.manual && (config.net.displayip || config.vnc || config.usessh)) {
@@ -317,7 +320,7 @@ int inst_choose_display()
 
     di = dia_menu2("Select the display type.", 33, inst_choose_display_cb, items, di_inst_choose_display_last);
 
-    return di == di_none ? -1 : 0;
+    return di == di_none ? 1 : 0;
   }
 }
 
@@ -358,7 +361,6 @@ int inst_choose_display_cb(dia_item_t di)
 
   return 0;
 }
-#endif
 
 
 /*
@@ -1132,12 +1134,10 @@ int inst_start_install()
     return 0;
   }
 
-#if defined(__s390__) || defined(__s390x__)
   if(!err &&
-    (config.net.setup & NS_DISPLAY) &&
+    (config.manual || (config.net.setup & NS_DISPLAY)) &&
     inst_choose_display()
   ) err = 1;
-#endif
 
   if(config.debug >= 2) util_status_info(1);
   

--- a/keyboard.c
+++ b/keyboard.c
@@ -183,10 +183,10 @@ void kbd_end(int close_fd)
 }
 
 
-void kbd_switch_tty(int tty)
+void kbd_switch_tty(int kbd_fd, int tty)
 {
-  ioctl(config.kbd_fd, VT_ACTIVATE, tty);
-  ioctl(config.kbd_fd, VT_WAITACTIVE, tty);
+  ioctl(kbd_fd, VT_ACTIVATE, tty);
+  ioctl(kbd_fd, VT_WAITACTIVE, tty);
 }
 
 

--- a/keyboard.h
+++ b/keyboard.h
@@ -63,7 +63,7 @@ extern void  kbd_reset        (void);
 extern void  kbd_end          (int close_fd);
 extern int   kbd_getch        (int wait_iv);
 extern void  kbd_clear_buffer (void);
-extern void  kbd_switch_tty   (int tty_iv);
+extern void  kbd_switch_tty   (int kbd_fd, int tty_iv);
 extern void  kbd_echo_off     (void);
 extern int   kbd_getch_old    (int);
 void kbd_unimode(void);

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1492,6 +1492,7 @@ void lxrc_check_console()
    * that terminal.
    */
   if(
+    !config.test &&
     (config.switch_to_fb == 2 || (config.switch_to_fb == 1 && !config.console_option)) &&
     util_check_exist("/dev/fb0") == 'c' &&
     util_check_exist(LXRC_CONSOLE_DEV) == 'c'
@@ -1909,7 +1910,7 @@ char *get_console_device()
 
   str_copy(&buf, NULL);
 
-  if((f = popen("showconsole", "r"))) {
+  if((f = popen("showconsole 2>/dev/null", "r"))) {
     if(getline(&buf, &len, f) > 0) {
       *strchrnul(buf, '\n') = 0;
     }

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE     /* getline, strchrnul */
+
 /*
  *
  * linuxrc.c     Load modules and rootimage to ramdisk
@@ -90,6 +92,7 @@ static void lxrc_makelinks(char *name);
 #endif
 static void select_repo_url(char *msg, char **repo);
 static char * get_platform_name();
+static char *get_console_device();
 
 #if SWISS_ARMY_KNIFE
 int probe_main(int argc, char **argv);
@@ -838,6 +841,7 @@ void lxrc_init()
 #if defined(__s390x__)
   config.device_auto_config = 2;	/* ask before doing s390 device auto config */
 #endif
+  config.switch_to_fb = 1;
 
   // defaults for self-update feature
   config.self_update_url = NULL;
@@ -990,8 +994,7 @@ void lxrc_init()
   );
 
   /*
-   * Do what has to be done before udevd starts; atm this is just the
-   * insmod.pre option.
+   * Do what has to be done before udevd starts.
    */
   file_read_info_file("cmdline", kf_cmd0);
 
@@ -1459,12 +1462,52 @@ return (1);
 }
 
 
-/* Check if we start linuxrc on a serial console. On Intel and
-   Alpha, we look if the "console" parameter was used on the
-   commandline. On SPARC, we use the result from hardwareprobing. */
+#define LXRC_CONSOLE_DEV "/dev/tty1"
+
+/*
+ * Set console device linuxrc is going to use.
+ *
+ * This is usually just /dev/console or something specified via the
+ * 'console' boot option.
+ *
+ * But if a framebuffer device exists (after udev loads some drivers) and
+ * the user hasn't specified any 'console' option, switch to
+ * LXRC_CONSOLE_DEV (that is, use the framebuffer).
+ *
+ * This console switching can be prevented using the 'switch_to_fb=0' boot
+ * option or enforced using 'switch_to_fb=2'. (The default setting is 1.)
+ */
 void lxrc_check_console()
 {
+  char *current_console = get_console_device();
+
   util_set_serial_console(auto2_serial_console());
+
+  /*
+   * Switch to tty1 if there is a framebuffer device and the user hasn't
+   * specified something else explicitly.
+   *
+   * The idea here is to catch cases where udev loads graphics drivers and a
+   * local graphical terminal becomes available. In this case, switch to
+   * that terminal.
+   */
+  if(
+    (config.switch_to_fb == 2 || (config.switch_to_fb == 1 && !config.console_option)) &&
+    util_check_exist("/dev/fb0") == 'c' &&
+    util_check_exist(LXRC_CONSOLE_DEV) == 'c'
+  ) {
+    if(strcmp(current_console, LXRC_CONSOLE_DEV)) {
+      str_copy(&config.console, LXRC_CONSOLE_DEV);
+      log_show(
+        "\nFramebuffer device detected - continuing installation on console %s.\n"
+        "Use boot option 'switch_to_fb=0' to prevent this.\n\n",
+        config.console
+      );
+      kbd_switch_tty(0, 1);
+    }
+  }
+
+  log_debug("going for console device: %s\n", config.console);
 
   if(config.serial) {
     log_info(
@@ -1850,4 +1893,32 @@ char * get_platform_name()
   str_copy(&platform, "");
 #endif
 return platform;
+}
+
+
+/*
+ * Get current console device name.
+ *
+ * Do not free() the returned string.
+ */
+char *get_console_device()
+{
+  FILE *f;
+  static char *buf = NULL;
+  size_t len;
+
+  str_copy(&buf, NULL);
+
+  if((f = popen("showconsole", "r"))) {
+    if(getline(&buf, &len, f) > 0) {
+      *strchrnul(buf, '\n') = 0;
+    }
+    pclose(f);
+  }
+
+  if(!buf) str_copy(&buf, "/dev/console");
+
+  log_info("get_console_device: %s\n", buf);
+
+  return buf;
 }

--- a/module.c
+++ b/module.c
@@ -711,7 +711,7 @@ int mod_insmod(char *module, char *param)
     util_update_disk_list(NULL, 1);
     util_update_cdrom_list();
 
-    if(mod_show_kernel_messages) kbd_switch_tty(4);
+    if(mod_show_kernel_messages) kbd_switch_tty(config.kbd_fd, 4);
   }
 
   err = lxrc_run(buf);
@@ -747,7 +747,7 @@ int mod_insmod(char *module, char *param)
       }
     }
 
-    if(mod_show_kernel_messages) kbd_switch_tty(1);
+    if(mod_show_kernel_messages) kbd_switch_tty(config.kbd_fd, 1);
 
     util_update_kernellog();
 

--- a/util.c
+++ b/util.c
@@ -553,6 +553,7 @@ int util_check_exist(char *file)
   if(S_ISREG(sbuf.st_mode)) return 'r';
   if(S_ISDIR(sbuf.st_mode)) return 'd';
   if(S_ISBLK(sbuf.st_mode)) return 'b';
+  if(S_ISCHR(sbuf.st_mode)) return 'c';
 
   return 1;
 }
@@ -1202,6 +1203,8 @@ void util_status_info(int log_it)
   sprintf(buf, "flags = ");
   add_flag(&sl0, buf, config.test, "test");
   add_flag(&sl0, buf, config.tmpfs, "tmpfs");
+  add_flag(&sl0, buf, config.console_option, "console");
+  add_flag(&sl0, buf, config.switch_to_fb, "switch2fb");
   add_flag(&sl0, buf, config.manual, "manual");
   add_flag(&sl0, buf, config.utf8, "utf8");
   add_flag(&sl0, buf, config.rescue, "rescue");


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1193910
- https://jira.suse.com/browse/SLE-18632
- https://trello.com/c/LX0JUO1E

(1) This dialog:

```
Select the display type.

0) <-- Back <--
1) X11               
2) VNC               
3) SSH               
4) ASCII Console          

>  4
```

is misleading and should be reworked (you get the graphical Qt UI choosing 4).

(2) The dialog should be shown on `/dev/tty1` if a framebuffer exists on s390x (and not on the serial line).

## See also

- https://github.com/openSUSE/installation-images/pull/564
- https://en.opensuse.org/SDB:Linuxrc#p_switch_to_fb

## Solution

1. Enable the dialog on all architectures. For better testing and it might be useful anyway. You get the dialog by adding `netsetup=display` to the boot options (on s390x this is the default setting).
2. Switch to tty1 if a framebuffer device is available after udevd has loaded modules.
3. Adjust menu:
    - rearranged, more common choices are at the top
    - added new GUI entry
    - renamed ASCII console -> Text-based UI, X11 -> remote X11
    - fixed workflow so that you can actually abort entering passwords and get back to this menu
4. To be on the safe side, there is a new option `switchtofb` that can be used to disable step 2. in case it causes trouble.
5. Note that YaST runs in an fbiterm when in text mode and the framebuffer is active.

```
Select the display type.

0) <-- Back <--
1) Graphical UI          
2) Text-based UI          
3) VNC               
4) SSH               
5) Remote X11           

> 1
```
