### PR TITLE
Migration away from kbd-legacy (jsc#SLE-21107)

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -68,7 +68,7 @@ static keymap_t set_keymaps_arm [] =
 { "Ceske",                "cz"           },
 { "Dansk",                "dk"           },
 { "Deutsch",              "de-nodeadkeys"},
-{ "English (UK)",         "uk"           },
+{ "English (UK)",         "gb"           },
 { "English (US)",         "us"           },
 { "Español",              "es"           },
 { "Français",             "fr"           },


### PR DESCRIPTION
## Trello + Jira

- Epic: https://jira.suse.com/browse/SLE-21107
- Dev task: https://jira.suse.com/browse/SLE-22101

- Trello: https://trello.com/c/4sCajesT/2728-feature-linuxrc-the-new-kbd-package


## Description

Since _kbd-legacy_ is now deprecated and will be removed soon, this makes sure to only rely on keyboard maps that are available from the new _kbd_ package; those below `/usr/share/kbd/keymaps/xkb`.

Fortunately, _linuxrc_ already used mostly keymaps from there. There were just a few exceptions:

- "uk" is now "gb"

Those are still needed, but not yet in the new _kbd_ package:

- Greek
- Russian

So we will need to keep _kbd-legacy_ for those languages until there is a proper replacement in the new _kbd_ package.


## Related PR (yast-country)

https://github.com/yast/yast-country/pull/288