### PR TITLE
s390x: ask for the VLAN id by default (jsc#SLE-18631)

### DIFF
--- a/global.h
+++ b/global.h
@@ -365,7 +365,7 @@ typedef struct {
 #define NS_NOW			(1 << 9)
 
 #if defined(__s390__) || defined(__s390x__)
-#define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER | NS_DISPLAY)
+#define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER | NS_DISPLAY | NS_VLANID)
 #else
 #define NS_DEFAULT		(NS_DHCP | NS_HOSTIP | NS_GATEWAY | NS_NAMESERVER)
 #endif


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/275 to SLE15-SP4.

## Original task

- https://trello.com/c/BV5JkVBk
- dev: https://jira.suse.com/browse/SLE-19610
- epic: https://jira.suse.com/browse/SLE-18631

Until now you'd have to specify netsetup=vlanid to get it.

From the epic: "Based on our experience with customers the large majority has VLAN segmented networks. If we can have this option available by default it might prevent some frustration for customers not 100% familiar with the SLES specifics."

Documented at <https://en.opensuse.org/SDB:Linuxrc#p_netsetup>

The network setup is affected by several boot time options.
When I use just `netsetup=1`,  there is a new VLAN question before the DHCP question.
When I use just `install=http...`, DHCP happens automatically and no VLAN question is asked.

The behavior was tested on my laptop with qemu in this way:
```console
$ sudo mksusecd -create vlanid.iso -initrd linuxrc-8.0.5-3.10.1.s390x.rpm SLE-15-SP3-Online-s390x-GM-Media1.iso 
$ (copy initrd out of vlanid.iso with MC)
$ qemu-system-s390x -M s390-ccw-virtio -kernel linux -initrd initrd -m 1024 -nographic --append netsetup=1
```

![linuxrc-vlan](https://user-images.githubusercontent.com/102056/133040912-3b259b69-425a-4f77-974f-9d57241521b5.png)