### PR TITLE
check also raid devices for install repo (bsc#1196061)

### DIFF
--- a/util.c
+++ b/util.c
@@ -4045,6 +4045,9 @@ void update_device_list(int force)
 
   config.hd_data = calloc(1, sizeof *config.hd_data);
 
+  // consider also raid devices
+  config.hd_data->flags.list_md = 1;
+
   fix_device_names(hd_list2(config.hd_data, hw_items, 1));
 
   // update wlan interface list


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1196061

Allow installation repository to be on RAID devices.

Adding `autoassembly=1` as boot option and using (for example) `install=hd:/foo/bar.iso` should find the installation repo even if it's located on a RAID volume.

## Solution

Setting the `list_md` flag for hardware probing ensures RAID devices are included in the disk list.

## See also

- https://en.opensuse.org/SDB:Linuxrc#p_autoassembly