### PR TITLE
do not leave repository mounted when starting yast (bsc#1196061)

### DIFF
--- a/file.c
+++ b/file.c
@@ -2014,7 +2014,9 @@ void file_write_install_inf(char *dir)
 
   file_write_str(f, key_console, config.serial);
 
-  file_write_num(f, key_sourcemounted, url->mount ? 1 : 0);
+  // don't leave anything mounted unless we're low in memory and run yast
+  // directly from the install medium
+  file_write_num(f, key_sourcemounted, url->mount && !config.download.instsys ? 1 : 0);
 
   fprintf(f, "RepoURL: %s\n", url_print(url, 3));
   if(!config.norepo)   fprintf(f, "ZyppRepoURL: %s\n", url_print(url, 4));

--- a/install.c
+++ b/install.c
@@ -1342,6 +1342,21 @@ int inst_execute_yast()
     return err;
   }
 
+  log_debug("= config.url.install =");
+  url_log(config.url.install);
+  log_debug("= config.url.instsys =");
+  url_log(config.url.instsys);
+
+  // we can't unmount if yast runs directly from the install medium
+  if(config.download.instsys) {
+    log_debug("unmounting installation medium");
+    url_umount(config.url.instsys);
+    url_umount(config.url.install);
+  }
+  else {
+    log_debug("insufficient memory - unmounting installation medium not possible");
+  }
+
   if(!config.test) {
     if(util_check_exist("/sbin/update")) lxrc_run("/sbin/update");
   }

--- a/url.c
+++ b/url.c
@@ -661,14 +661,17 @@ url_t *url_set(char *str)
     }
   }
 
-  log_debug("url = %s\n", url->str);
-
   url_replace_vars_with_backup(&url->server, &url->orig.server);
   url_replace_vars_with_backup(&url->share, &url->orig.share);
   url_replace_vars_with_backup(&url->path, &url->orig.path);
   url_replace_vars_with_backup(&url->instsys, &url->orig.instsys);
 
-  if(config.debug >= 2) url_log(url);
+  if(config.debug >= 2) {
+    url_log(url);
+  }
+  else {
+    log_debug("url = %s\n", url->str);
+  }
 
   return url;
 }
@@ -682,17 +685,20 @@ void url_log(url_t *url)
   int i;
   slist_t *sl;
 
+  if(!url) return;
+
+  log_debug("url = %s\n", url->str);
+
   log_debug(
     "  scheme = %s (%d), orig scheme = %s (%d)",
     url_scheme2name(url->scheme), url->scheme,
     url_scheme2name(url->orig.scheme), url->orig.scheme
   );
-  if(url->server) log_debug(", server = \"%s\"", url->server);
-  if(url->orig.server) log_debug(", server (orig) = \"%s\"", url->orig.server);
-  if(url->port) log_debug(", port = %u", url->port);
-  if(url->path) log_debug(", path = \"%s\"", url->path);
-  if(url->orig.path) log_debug(", path (orig) = \"%s\"", url->orig.path);
-  log_debug("\n");
+  if(url->server) log_debug("  server = \"%s\"", url->server);
+  if(url->orig.server) log_debug("  server (orig) = \"%s\"", url->orig.server);
+  if(url->port) log_debug("  port = %u", url->port);
+  if(url->path) log_debug("  path = \"%s\"", url->path);
+  if(url->orig.path) log_debug("  path (orig) = \"%s\"", url->orig.path);
 
   if(url->user || url->password) {
     i = 0;
@@ -702,12 +708,10 @@ void url_log(url_t *url)
   }
 
   if(url->share || url->domain || url->device) {
-    i = 0;
-    if(url->share) log_debug("%c share = \"%s\"", i++ ? ',' : ' ', url->share);
-    if(url->orig.share) log_debug("%c share (orig) = \"%s\"", i++ ? ',' : ' ', url->orig.share);
-    if(url->domain) log_debug("%c domain = \"%s\"", i++ ? ',' : ' ', url->domain);
-    if(url->device) log_debug("%c device = \"%s\"", i++ ? ',' : ' ', url->device);
-    log_debug("\n");
+    if(url->share) log_debug("  share = \"%s\"", url->share);
+    if(url->orig.share) log_debug("  share (orig) = \"%s\"", url->orig.share);
+    if(url->domain) log_debug("  domain = \"%s\"", url->domain);
+    if(url->device) log_debug("  device = \"%s\"", url->device);
   }
 
   log_debug(
@@ -726,8 +730,10 @@ void url_log(url_t *url)
     }
   }
 
-  log_debug("url (zypp format) = %s\n", url_print(url, 4));
-  log_debug("url (ay format) = %s\n", url_print(url, 5));
+  log_debug("  mount = %s, tmp_mount = %s\n", url->mount, url->tmp_mount);
+
+  log_debug("  url (zypp format) = %s\n", url_print(url, 4));
+  log_debug("  url (ay format) = %s\n", url_print(url, 5));
 }
 
 

--- a/url.c
+++ b/url.c
@@ -1493,22 +1493,31 @@ int url_progress(url_data_t *url_data, int stage)
 
 /*
  * Unmounts volumes used by 'url'.
+ *
+ * Return error code (0 if ok).
  */
-void url_umount(url_t *url)
+int url_umount(url_t *url)
 {
-  if(!url) return;
-
-  // FIXME: this is wrong!
+  int err = 0;
+  if(!url) return 0;
 
   if(url->mount && util_umount(url->mount)) {
     log_debug("%s: url umount failed\n", url->mount);
+    err = 1;
   }
-  str_copy(&url->mount, NULL);
+  else {
+    str_copy(&url->mount, NULL);
+  }
 
   if(url->tmp_mount && util_umount(url->tmp_mount)) {
     log_debug("%s: url umount failed\n", url->tmp_mount);
+    err = 1;
   }
-  str_copy(&url->tmp_mount, NULL);
+  else {
+    str_copy(&url->tmp_mount, NULL);
+  }
+
+  return err;
 }
 
 

--- a/url.h
+++ b/url.h
@@ -56,7 +56,7 @@ url_t *url_free(url_t *url);
 void url_cleanup(void);
 url_data_t *url_data_new(void);
 void url_data_free(url_data_t *url_data);
-void url_umount(url_t *url);
+int url_umount(url_t *url);
 int url_mount(url_t *url, char *dir, int (*test_func)(url_t *));
 int url_read_file(url_t *url, char *dir, char *src, char *dst, char *label, unsigned flags);
 int url_read_file_anywhere(url_t *url, char *dir, char *src, char *dst, char *label, unsigned flags);


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1196061
- https://trello.com/c/bC5yVZas

linuxrc traditionally leaves the installation medium mounted when starting yast. This is not strictly necessary.

Do not do this, as this interferes with YaST's media handling and extension loading via `extend`.