### PR TITLE
fix typo in HiperSocket (bsc#1198821)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -106,7 +106,7 @@ struct {
   { di_390net_ctc,	 "Channel To Channel (CTC)"	          },
   { di_390net_escon,	 "ESCON"         },
   { di_390net_iucv,	 "Inter-User Communication Vehicle (IUCV)"          },
-  { di_390net_hsi,	 "Hipersockets"	          },
+  { di_390net_hsi,	 "HiperSockets"	          },
   { di_390net_virtio,	 "VirtIO Ethernet CCW Device"},
   { di_390net_sep,	 "#--------------------" },
   

--- a/net.c
+++ b/net.c
@@ -618,7 +618,7 @@ int net_choose_device()
     { "escon", "ESCON connection" },
     { "ci",    "channel attached cisco router"  },
     { "iucv",  "IUCV connection"  },
-    { "hsi",   "Hipersocket"   }
+    { "hsi",   "HiperSocket"   }
   };
   hd_data_t *hd_data = calloc(1, sizeof *hd_data);
   hd_t *hd, *hd_cards;


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1198821 (internal only)

Issue: Typo in displayed human readable string

Solution: Fix typo