### PR TITLE
add 'repo' URL scheme to linuxrc (jsc#SLE-22578, jsc#SLE-24584)

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -888,7 +888,7 @@ void auto2_read_repo_files(url_t *url)
 
   if(config.url.autoyast) {
     if(
-      config.url.autoyast->scheme == inst_rel &&
+      (config.url.autoyast->scheme == inst_rel || config.url.autoyast->scheme == inst_repo) &&
       config.autoyast_parse
     ) {
       log_show_maybe(!config.url.autoyast->quiet, "AutoYaST file in repo: %s\n", url_print(config.url.autoyast, 5));
@@ -908,9 +908,12 @@ void auto2_read_repo_files(url_t *url)
     if(util_check_exist("/tmp/autoinst.xml")) rename("/tmp/autoinst.xml", "/autoinst.xml");
 
     if(util_check_exist("/autoinst.xml")) {
-      log_info("setting AutoYaST option to file:/autoinst.xml\n");
-      url_free(config.url.autoyast);
-      config.url.autoyast = url_set("file:/autoinst.xml");
+      // with repo scheme, pass the the original URL to yast
+      if(config.url.autoyast->scheme != inst_repo) {
+        log_info("setting AutoYaST option to file:/autoinst.xml\n");
+        url_free(config.url.autoyast);
+        config.url.autoyast = url_set("file:/autoinst.xml");
+      }
       // parse for embedded linuxrc options in <info_file> element
       log_info("parsing AutoYaST file\n");
       file_read_info_file("file:/autoinst.xml", kf_cfg);
@@ -1095,7 +1098,7 @@ int auto2_add_extension(char *extension)
     err = 1;
   }
 
-  if(config.url.instsys->scheme == inst_rel && !config.url.install) {
+  if((config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo)  && !config.url.install) {
     log_info("no repo\n");
     err = 2;
   }
@@ -1107,7 +1110,7 @@ int auto2_add_extension(char *extension)
 
   strprintf(&config.url.instsys->path, "%s/%s", s, extension);
 
-  if(config.url.instsys->scheme == inst_rel) {
+  if(config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo) {
     err = url_find_repo(config.url.install, config.mountpoint.instdata);
   }
 
@@ -1227,7 +1230,7 @@ void auto2_read_autoyast(url_t *url)
   if(!url) return;
 
   // rel url is taken care of in auto2_read_repo_files()
-  if(url->scheme == inst_rel) return;
+  if(url->scheme == inst_rel || url->scheme == inst_repo) return;
 
   /*
    * If the AutoYaST url is a directory we have to verify its existence

--- a/global.h
+++ b/global.h
@@ -185,7 +185,7 @@ typedef enum {
   inst_none = 0, inst_file, inst_nfs, inst_ftp, inst_smb,
   inst_http, inst_https, inst_tftp, inst_cdrom, inst_floppy, inst_hd,
   inst_dvd, inst_cdwithnet, inst_net, inst_slp, inst_exec,
-  inst_rel, inst_disk, inst_usb, inst_label,
+  inst_rel, inst_disk, inst_usb, inst_label, inst_repo,
   inst_extern ///< must be last
 } instmode_t;
 

--- a/url.c
+++ b/url.c
@@ -122,6 +122,7 @@ static struct {
   { "disk",      inst_disk          },
   { "usb",       inst_usb           },
   { "label",     inst_label         },
+  { "repo",      inst_repo          },
   /* add new inst modes _here_! (before "extern") */
   { "extern",    inst_extern        },
   /* the following are just aliases */
@@ -2675,7 +2676,10 @@ static int test_is_repo(url_t *url)
     str_copy(&buf2, NULL);
   }
 
-  if(config.url.instsys->scheme != inst_rel || config.kexec == 1) return 1;
+  if(
+    (config.url.instsys->scheme != inst_rel && config.url.instsys->scheme != inst_repo) ||
+    config.kexec == 1
+  ) return 1;
 
   if(!config.keepinstsysconfig) {
     instsys_config = url_instsys_config(config.url.instsys->path);
@@ -2875,6 +2879,7 @@ int url_find_instsys(url_t *url, char *dir)
     !url ||
     !url->scheme ||
     url->scheme == inst_rel ||
+    url->scheme == inst_repo ||
     !url->path
   ) return 1;
 


### PR DESCRIPTION
The scheme is basically the same as 'rel' - that is, relative to the
installation repository with the difference that it is never rewritten to
point to the actual location but passed to yast in unmodified form.