### PR TITLE
s390x: remove deprecated ESCON support (jsc#PED-595)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -104,7 +104,6 @@ struct {
   
   { di_390net_osa,	 "OSA-2 or OSA Express"           },
   { di_390net_ctc,	 "Channel To Channel (CTC)"	          },
-  { di_390net_escon,	 "ESCON"         },
   { di_390net_iucv,	 "Inter-User Communication Vehicle (IUCV)"          },
   { di_390net_hsi,	 "HiperSockets"	          },
   { di_390net_virtio,	 "VirtIO Ethernet CCW Device"},

--- a/dialog.h
+++ b/dialog.h
@@ -84,7 +84,6 @@ typedef enum {
 
   di_390net_osa,
   di_390net_ctc,
-  di_390net_escon,
   di_390net_iucv,
   di_390net_hsi,
   di_390net_virtio,

--- a/file.c
+++ b/file.c
@@ -327,6 +327,7 @@ static struct {
   { key_extend,         "Extend",         kf_cfg + kf_cmd                },
   { key_switch_to_fb,   "SwitchToFB",     kf_cfg + kf_cmd_early          },
   { key_edid,           "EDID",           kf_cmd_early                   },
+  { key_hypervisor,     "Hypervisor",     kf_cmd_early                   },
 };
 
 static struct {
@@ -1901,6 +1902,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
 
       case key_edid:
         if(*f->value) util_parse_edid(f->value);
+        break;
+
+      case key_hypervisor:
+        str_copy(&config.hwp.hypervisor, f->value);
         break;
 
       default:

--- a/file.c
+++ b/file.c
@@ -352,7 +352,6 @@ static struct {
 #if defined(__s390__) || defined(__s390x__)
   { "osa",	 di_390net_osa      },
   { "ctc",	 di_390net_ctc	    },
-  { "escon",	 di_390net_escon    },
   { "iucv",	 di_390net_iucv     },
   { "hsi",	 di_390net_hsi	    },
   { "qdio",	 di_osa_qdio	    },

--- a/file.h
+++ b/file.h
@@ -58,7 +58,8 @@ typedef enum {
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
   key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
-  key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb, key_edid
+  key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb, key_edid,
+  key_hypervisor
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -737,7 +737,6 @@ typedef struct {
     log_file_t dest[3];		/**< logging destinations, see linuxrc.c */
   } log;
 
-#if defined(__s390__) || defined(__s390x__)
   /* hwcfg file parameters */
   struct {
     char* userid;
@@ -762,9 +761,6 @@ typedef struct {
     char* osahwaddr;
     char* hypervisor;
   } hwp;
-  
-#endif
-
 } config_t;
 
 extern config_t config;

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -762,7 +762,10 @@ void lxrc_init()
 
   util_setup_coredumps();
 
-  #if defined(__s390__) || defined(__s390x__)
+  /*
+   * config.hwp.hypervisor is a s390 specific setting
+   */
+  str_copy(&config.hwp.hypervisor, "Reallyunknown");
   if(util_check_exist("/sys/hypervisor/s390")) {
     char *type;
 
@@ -771,23 +774,21 @@ void lxrc_init()
     type = util_get_attr("/sys/hypervisor/s390/hyp/type");
 
     if(!strncmp(type, "z/VM", sizeof "z/VM" - 1)) {
-      config.hwp.hypervisor = "z/VM";
+      str_copy(&config.hwp.hypervisor, "z/VM");
     }
     else if(!strncmp(type, "LPAR", sizeof "LPAR" - 1)) {
-      config.hwp.hypervisor = "LPAR";
+      str_copy(&config.hwp.hypervisor, "LPAR");
     }
     else {
-      config.hwp.hypervisor = "Unknown";
+      str_copy(&config.hwp.hypervisor, "Unknown");
     }
   }
   else {
     struct utsname utsinfo;
 
     uname(&utsinfo);
-    if(!strncmp(utsinfo.machine, "s390x", sizeof "s390x" - 1 )) config.hwp.hypervisor="KVM";
-    else config.hwp.hypervisor="Reallyunknown";
+    if(!strncmp(utsinfo.machine, "s390x", sizeof "s390x" - 1 )) str_copy(&config.hwp.hypervisor, "KVM");
   }
-  #endif
 
   /* add cmdline to info file */
   config.info.add_cmdline = 1;

--- a/linuxrc.html
+++ b/linuxrc.html
@@ -1452,7 +1452,6 @@ set this to 0. (Don't do this.)
  osa OSA-2 or OSA Express
  hsi Hipersocket
  ctc CTC (deprecated)
- escon ESCON (deprecated)
  iucv IUCV (deprecated)
 </pre>
 </td></tr>

--- a/net.c
+++ b/net.c
@@ -638,7 +638,7 @@ int net_choose_device()
      IUCV is available for use unless the driver is already loaded. So,
      if we're running on z/VM we always load it, no matter what.       */
   #if defined(__s390__) || defined(__s390x__)
-  if(!strncmp(config.hwp.hypervisor, "z/VM", sizeof "z/VM" - 1 )) {
+  if(!strcmp(config.hwp.hypervisor, "z/VM")) {
      dia_info(&win, "We are running on z/VM", MSGTYPE_INFO);
      dia_info(&win, "Loading the IUCV network driver", MSGTYPE_INFO);
      mod_modprobe("netiucv","");
@@ -1419,7 +1419,7 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       di_390net_iucv,
       di_none
     };
-    if(!strncmp(config.hwp.hypervisor, "KVM", sizeof "KVM" - 1)) {
+    if(!strcmp(config.hwp.hypervisor, "KVM")) {
       config.hwp.type = di_390net_virtio;
     }
     else {

--- a/net.c
+++ b/net.c
@@ -615,7 +615,6 @@ int net_choose_device()
     { "fddi",  "FDDI network card"  },
     { "hip",   "HIPPI network card" },
     { "ctc",   "channel to channel connection"   },
-    { "escon", "ESCON connection" },
     { "ci",    "channel attached cisco router"  },
     { "iucv",  "IUCV connection"  },
     { "hsi",   "HiperSocket"   }
@@ -1403,9 +1402,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
   case 0x88:	/* CTC */
     config.hwp.type = di_390net_ctc;
     break;
-  case 0x8f:	/* ESCON */
-    config.hwp.type = di_390net_escon;
-    break;
   default:
     return -1;
   }
@@ -1415,7 +1411,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       di_390net_hsi,
       di_390net_sep,
       di_390net_ctc,
-      di_390net_escon,
       di_390net_iucv,
       di_none
     };
@@ -1448,7 +1443,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
     break;
 
   case di_390net_ctc:
-  case di_390net_escon:
     if(mod_modprobe("ctcm",NULL)) {
       dia_message("failed to load ctcm module",MSGTYPE_ERROR);
       return -1;
@@ -1593,7 +1587,6 @@ int net_activate_s390_devs_ex(hd_t* hd, char** device)
       sprintf(cmd, "iucv_configure %s 1", config.hwp.userid);
       break;
     case di_390net_ctc:
-    case di_390net_escon:
       if(config.hwp.protocol > 0)
         sprintf(cmd, "/sbin/chzdev -e ctc --no-root-update %s-%s protocol=%d", config.hwp.readchan, config.hwp.writechan, config.hwp.protocol - 1);
       else


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/PED-595

ESCON has been deprecated for some time. Remove it from interactive dialogs.

## See also

- same for SLE15-SP4: https://github.com/openSUSE/linuxrc/pull/303
- same for SLE15-SP5: 