### PR TITLE
fix typo in HiperSocket (bsc#1198821)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -105,7 +105,7 @@ struct {
   { di_390net_osa,	 "OSA-2 or OSA Express"           },
   { di_390net_ctc,	 "Channel To Channel (CTC)"	          },
   { di_390net_iucv,	 "Inter-User Communication Vehicle (IUCV)"          },
-  { di_390net_hsi,	 "Hipersockets"	          },
+  { di_390net_hsi,	 "HiperSockets"	          },
   { di_390net_virtio,	 "VirtIO Ethernet CCW Device"},
   { di_390net_sep,	 "#--------------------" },
   { di_390net_pci,      "PCI-attached networking device" },

--- a/net.c
+++ b/net.c
@@ -617,7 +617,7 @@ int net_choose_device()
     { "ctc",   "channel to channel connection"   },
     { "ci",    "channel attached cisco router"  },
     { "iucv",  "IUCV connection"  },
-    { "hsi",   "Hipersocket"   }
+    { "hsi",   "HiperSocket"   }
   };
   hd_data_t *hd_data = calloc(1, sizeof *hd_data);
   hd_t *hd, *hd_cards;


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/295 to SLE15-SP5.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1198821

Typo: "Hipersocket" should be "HiperSocket".