### PR TITLE
support more general wicked firmware devices interface (jsc#PED-3118, jsc#PED-967)

### DIFF
--- a/file.c
+++ b/file.c
@@ -315,7 +315,8 @@ static struct {
   { key_sethostname,    "SetHostname",    kf_cfg + kf_cmd_early          },
   { key_debugshell,     "DebugShell",     kf_cfg + kf_cmd + kf_cmd_early },
   { key_self_update,    "SelfUpdate",     kf_cfg + kf_cmd                },
-  { key_ibft_devices,   "IBFTDevices",    kf_cfg + kf_cmd                },
+  { key_firmware_devices, "FirmwareDevices", kf_cfg + kf_cmd             },
+  { key_firmware_devices, "IBFTDevices",  kf_cfg + kf_cmd                },
   { key_linuxrc_core,   "LinuxrcCore",    kf_cfg + kf_cmd_early          },
   { key_norepo,         "NoRepo",         kf_cfg + kf_cmd                },
   { key_auto_assembly,  "AutoAssembly",   kf_cfg + kf_cmd_early          },
@@ -1844,8 +1845,8 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         }
         break;
 
-      case key_ibft_devices:
-        slist_assign_values(&config.ifcfg.ibft, f->value);
+      case key_firmware_devices:
+        slist_assign_values(&config.ifcfg.firmware, f->value);
         break;
 
       case key_linuxrc_core:

--- a/file.c
+++ b/file.c
@@ -329,6 +329,7 @@ static struct {
   { key_switch_to_fb,   "SwitchToFB",     kf_cfg + kf_cmd_early          },
   { key_edid,           "EDID",           kf_cmd_early                   },
   { key_hypervisor,     "Hypervisor",     kf_cmd_early                   },
+  { key_usenbft,        "UseNBFT",        kf_cfg + kf_cmd                },
 };
 
 static struct {
@@ -1467,6 +1468,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         if(f->is.numeric) config.withfcoe = f->nvalue;
         break;
 
+      case key_usenbft:
+        if(f->is.numeric) config.usenbft = f->nvalue;
+        break;
+
       case key_startshell:
         if(!*f->value) config.startshell = 1;
         if(f->is.numeric) config.startshell = f->nvalue;
@@ -1849,6 +1854,10 @@ void file_do_info(file_t *f0, file_key_flag_t flags)
         slist_assign_values(&config.ifcfg.firmware, f->value);
         break;
 
+      case key_firmware_types:
+        slist_assign_values(&config.ifcfg.firmware_types, f->value);
+        break;
+
       case key_linuxrc_core:
         str_copy(&config.core, *f->value ? f->value : NULL);
         break;
@@ -2077,6 +2086,7 @@ void file_write_install_inf(char *dir)
   file_write_str(f, key_instsys_id, config.instsys_id);
   file_write_num(f, key_withiscsi, config.withiscsi);
   file_write_num(f, key_withfcoe, config.withfcoe);
+  file_write_num(f, key_usenbft, config.usenbft);
   file_write_num(f, key_startshell, config.startshell);
   file_write_num(f, key_y2gdb, config.y2gdb);
   file_write_num(f, key_kexec_reboot, config.kexec_reboot);

--- a/file.h
+++ b/file.h
@@ -56,7 +56,7 @@ typedef enum {
   key_withipoib, key_upgrade, key_media_upgrade, key_ifcfg, key_defaultinstall,
   key_nanny, key_vlanid,
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
-  key_ibft_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
+  key_firmware_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
   key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
   key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb, key_edid,
   key_hypervisor

--- a/file.h
+++ b/file.h
@@ -58,8 +58,8 @@ typedef enum {
   key_sshkey, key_systemboot, key_sethostname, key_debugshell, key_self_update,
   key_firmware_devices, key_linuxrc_core, key_norepo, key_auto_assembly, key_autoyast_parse,
   key_device_auto_config, key_autoyast_passurl, key_rd_zdev, key_insmod_pre,
-  key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb, key_edid,
-  key_hypervisor
+  key_zram, key_zram_root, key_zram_swap, key_extend, key_switch_to_fb, key_edid, key_hypervisor,
+  key_usenbft, key_firmware_types
 } file_key_t;
 
 typedef enum {

--- a/global.h
+++ b/global.h
@@ -721,7 +721,7 @@ typedef struct {
     slist_t *if_up;		/**< network interfaces != lo that are 'up' */
     char *current;		/**< interface name for last written ifcfg file */
     slist_t *to_global;		/**< keys that go to global /etc/sysconfig/network/config */
-    slist_t *ibft;		/**< list of ibft interfaces (not to be configured by linuxrc) */
+    slist_t *firmware;		/**< list of firmware interfaces (e.g. ibft, nbft -- they are not to be configured by linuxrc) */
   } ifcfg;
 
   struct {

--- a/global.h
+++ b/global.h
@@ -437,6 +437,7 @@ typedef struct {
   unsigned withiscsi;		/**< iSCSI parameter */
   unsigned withfcoe;		/**< FCoE parameter */
   unsigned withipoib;		/**< IPoIB */
+  unsigned usenbft;		/**< use NBFT info to activate disk (for yast) */
   unsigned restart_method;	/**< 0: start new root fs, 1: reboot, 2: halt, 3: kexec */
   unsigned efi_vars:1;		/**< efi vars exist */
   int efi;			/**< use efi; -1 = auto */
@@ -721,7 +722,8 @@ typedef struct {
     slist_t *if_up;		/**< network interfaces != lo that are 'up' */
     char *current;		/**< interface name for last written ifcfg file */
     slist_t *to_global;		/**< keys that go to global /etc/sysconfig/network/config */
-    slist_t *firmware;		/**< list of firmware interfaces (e.g. ibft, nbft -- they are not to be configured by linuxrc) */
+    slist_t *firmware;		/**< list of network interfaces handled by firmware (they are not to be configured by linuxrc) */
+    slist_t *firmware_types;	/**< list of firmware interfaces types (e.g. ibft, nbft) */
   } ifcfg;
 
   struct {

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1036,10 +1036,15 @@ void lxrc_init()
 
   util_run_script("early_setup");
 
-  file_read_info_file("file:/etc/ibft_devices", kf_cfg);
+  if(util_check_exist("/etc/firmware_devices")) {
+    file_read_info_file("file:/etc/firmware_devices", kf_cfg);
+  }
+  else if(util_check_exist("/etc/ibft_devices")) {
+    file_read_info_file("file:/etc/ibft_devices", kf_cfg);
+  }
 
-  // ibft interfaces are handled by wicked
-  for(sl = config.ifcfg.ibft; sl; sl = sl->next) {
+  // firmware interfaces are handled by wicked
+  for(sl = config.ifcfg.firmware; sl; sl = sl->next) {
     slist_append_str(&config.ifcfg.initial, sl->key);
   }
 

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1038,6 +1038,7 @@ void lxrc_init()
 
   if(util_check_exist("/etc/firmware_devices")) {
     file_read_info_file("file:/etc/firmware_devices", kf_cfg);
+    file_read_info_file("file:/etc/firmware_types", kf_cfg);
   }
   else if(util_check_exist("/etc/ibft_devices")) {
     file_read_info_file("file:/etc/ibft_devices", kf_cfg);
@@ -1133,6 +1134,7 @@ void lxrc_init()
 
   if(iscsi_check()) config.withiscsi = 1;
   if(fcoe_check()) config.withfcoe = 1;
+  if(nbft_check()) config.usenbft = 1;
 
   LXRC_WAIT
 

--- a/util.c
+++ b/util.c
@@ -1334,10 +1334,10 @@ void util_status_info(int log_it)
     }
   }
 
-  if(config.ifcfg.ibft) {
-    strcpy(buf, "ibft interfaces:");
+  if(config.ifcfg.firmware) {
+    strcpy(buf, "firmware interfaces:");
     slist_append_str(&sl0, buf);
-    for(sl = config.ifcfg.ibft; sl; sl = sl->next) {
+    for(sl = config.ifcfg.firmware; sl; sl = sl->next) {
       if(!sl->key) continue;
       sprintf(buf, "  %s", sl->key);
       slist_append_str(&sl0, buf);

--- a/util.c
+++ b/util.c
@@ -1344,6 +1344,16 @@ void util_status_info(int log_it)
     }
   }
 
+  if(config.ifcfg.firmware_types) {
+    strcpy(buf, "firmware interface types:");
+    slist_append_str(&sl0, buf);
+    for(sl = config.ifcfg.firmware_types; sl; sl = sl->next) {
+      if(!sl->key) continue;
+      sprintf(buf, "  %s", sl->key);
+      slist_append_str(&sl0, buf);
+    }
+  }
+
   if(config.ifcfg.if_state) {
     strcpy(buf, "network interface states:");
     slist_append_str(&sl0, buf);
@@ -4552,6 +4562,17 @@ int iscsi_check()
   str_copy(&ibft_mac, NULL);
 
   return 1;
+}
+
+
+/*
+ * Don't actually do anything except checking for NBFT data.
+ *
+ * NBFT interfaces are handled by wicked.
+ */
+int nbft_check()
+{
+  return slist_getentry(config.ifcfg.firmware_types, "nbft") ? 1 : 0;
 }
 
 

--- a/util.h
+++ b/util.h
@@ -133,6 +133,7 @@ hd_t *fix_device_names(hd_t *hd);
 
 int fcoe_check(void);
 int iscsi_check(void);
+int nbft_check(void);
 
 char *interface_to_mac(char *device);
 char *mac_to_interface(char *mac, int *max_offset);


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/310 to Tumbleweed.

## Original task

- https://jira.suse.com/browse/PED-967
- https://jira.suse.com/browse/PED-3118

wicked now has a more general extension that lists firmware handled network interfaces (not just ibft).

From linuxrc's perspective all these interfaces should just be ignored (not offered for configuration). They are set up by a `wicked ifup all` call.

## See also

- https://github.com/openSUSE/installation-images/pull/621