### PR TITLE
be careful switch_to_fb option takes care of textmode setting (bsc#1206460)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -1498,6 +1498,8 @@ void lxrc_check_console()
 {
   char *current_console = get_console_device();
 
+  unsigned textmode_initial = config.textmode;
+
   util_set_serial_console(auto2_serial_console());
 
   /*
@@ -1522,6 +1524,8 @@ void lxrc_check_console()
         config.console
       );
       kbd_switch_tty(0, 1);
+      /* restore user-provided textmode setting (util_set_serial_console() might have changed it) */
+      config.textmode = textmode_initial;
     }
   }
 


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/linuxrc/pull/312 to SLE15-SP4.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1206460

The `switch_to_fb` option takes care of switching to a graphics console if one becomes available. But linuxrc might have decided earlier to go for text mode because it has seen a serial console.

Revert that decision when switching consoles.