### PR TITLE
really parse 'firmwaretype' key (bsc#1208042)

### DIFF
--- a/file.c
+++ b/file.c
@@ -330,6 +330,7 @@ static struct {
   { key_edid,           "EDID",           kf_cmd_early                   },
   { key_hypervisor,     "Hypervisor",     kf_cmd_early                   },
   { key_usenbft,        "UseNBFT",        kf_cfg + kf_cmd                },
+  { key_firmware_types, "FirmwareTypes",  kf_cfg + kf_cmd                },
 };
 
 static struct {


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1208042

NFBT is not detected properly even though `/etc/firmware_types` has an `nbft` entry.

## Analysis

The `fimwaretypes` key was not actually added to the parser.