### PR TITLE
Fixing Length of service type list field on Service Request package.

### DIFF
--- a/slp.c
+++ b/slp.c
@@ -230,12 +230,20 @@ char *slp_get_install(url_t *url)
   bp = sendbuf + 16;
   *bp++ = 0;
   *bp++ = 0;	/* prlistlen */
-  memcpy(bp, "\000\024service:", sizeof "\000\024service:" - 1);
-  bp += sizeof "\000\024service:" - 1;
+
+  /* Get service name, use default if not set */
   sl = slist_getentry(url->query, "service");
   service = sl ? sl->value : "install.suse";
+  
+  *(bp++) = 0x00;
+  *(bp++) = strlen(service) + 8;
+
+  memcpy(bp, "service:", sizeof "service:");
+  bp += sizeof("service:"-1);
+
   memcpy(bp, service, strlen(service));
   bp += strlen(service);
+
   memcpy(bp, "\000\007default", 7 + 2);
   bp += 7 + 2;
 


### PR DESCRIPTION
Fixes the length of the service type field on Service Request package, it was fixed on code and causing 'malformed packet' when using a customized service name (Issue #322)