### PR TITLE
fix length of service type list field in SLP request (bsc#1213683)

### DIFF
--- a/slp.c
+++ b/slp.c
@@ -472,6 +472,9 @@ char *slp_get_install(url_t *url)
   set_activate_language(config.language);
   if(!config.win) util_disp_init();
   *urlbuf = 0;
+  int select_first = 0;
+  sl = slist_getentry(url->query, "auto");
+  if(sl && !strcmp(sl->value, "1")) select_first = 1;
   for (;;)
     {
       sl = slist_getentry(url->query, "descr");
@@ -479,7 +482,7 @@ char *slp_get_install(url_t *url)
 
       while(1) {
         for(i = acnt = 0; i < urlcnt; i++) {
-          if(key && fnmatch(key, descs[i], FNM_CASEFOLD)) continue;
+          if(key && fnmatch(key, descs[i], FNM_EXTMATCH + FNM_CASEFOLD)) continue;
           if(acnt == 0 || strcmp(descs[i], ambg[acnt - 1])) {
             ambg[acnt++] = descs[i];
           }
@@ -488,6 +491,8 @@ char *slp_get_install(url_t *url)
         if(acnt || !key) break;
         str_copy(&key, NULL);
       }
+
+      if(select_first && acnt > 1) acnt = 1;
 
       i = acnt == 1 && !config.manual ? 1 : dia_list("Choose an installation source", 70, NULL, ambg, 0, align_left);
       if (i <= 0 || i > acnt)
@@ -499,7 +504,7 @@ char *slp_get_install(url_t *url)
 
       while(1) {
         for(i = acnt = 0; i < urlcnt; i++) {
-          if(key && fnmatch(key, urls[i], FNM_CASEFOLD)) continue;
+          if(key && fnmatch(key, urls[i], FNM_EXTMATCH + FNM_CASEFOLD)) continue;
           if(!strcmp(descs[i], d)) {
             ambg[acnt++] = urls[i];
           }
@@ -510,6 +515,8 @@ char *slp_get_install(url_t *url)
       }
 
       if(acnt == 0) break;
+
+      if(select_first && acnt > 1) acnt = 1;
 
       i = acnt == 1 ? 1 : dia_list("Choose an installation source", 70, NULL, ambg, 0, align_left);
 

--- a/slp.c
+++ b/slp.c
@@ -473,8 +473,9 @@ char *slp_get_install(url_t *url)
   if(!config.win) util_disp_init();
   *urlbuf = 0;
   int select_first = 0;
-  sl = slist_getentry(url->query, "auto");
-  if(sl && !strcmp(sl->value, "1")) select_first = 1;
+  if((sl = slist_getentry(url->query, "auto"))) {
+    select_first = sl->value ? strtoul(sl->value, NULL, 0) : 1;
+  }
   for (;;)
     {
       sl = slist_getentry(url->query, "descr");

--- a/slp.c
+++ b/slp.c
@@ -230,12 +230,25 @@ char *slp_get_install(url_t *url)
   bp = sendbuf + 16;
   *bp++ = 0;
   *bp++ = 0;	/* prlistlen */
-  memcpy(bp, "\000\024service:", sizeof "\000\024service:" - 1);
-  bp += sizeof "\000\024service:" - 1;
+
+  /*
+   * Format note: each string (strings are not 0-terminated) is preceded by
+   * a 16-bit big-endian encoded length.
+   */
+
+  /* Get service name, use default if not set */
   sl = slist_getentry(url->query, "service");
   service = sl ? sl->value : "install.suse";
+
+  *(bp++) = 0x00;
+  *(bp++) = strlen(service) + sizeof "service:" - 1;
+
+  memcpy(bp, "service:", sizeof "service:" - 1);
+  bp += sizeof "service:" - 1;
+
   memcpy(bp, service, strlen(service));
   bp += strlen(service);
+
   memcpy(bp, "\000\007default", 7 + 2);
   bp += 7 + 2;
 

--- a/url.c
+++ b/url.c
@@ -888,7 +888,7 @@ void url_add_query_string(char **buf, int n, url_t *url)
 
   for(sl = url->query; sl; sl = sl->next) {
     // skip parameters handled by linuxrc
-    if(fnmatch("@(device|instsys|list|type|all|quiet|label|service|descr|proxy*)", sl->key, FNM_EXTMATCH)) {
+    if(fnmatch("@(device|instsys|list|type|all|quiet|label|service|descr|proxy*|url|auto)", sl->key, FNM_EXTMATCH)) {
       strprintf(buf, "%s%c%s=%s", *buf, n++ ? '&' : '?', sl->key, sl->value);
     }
   }

--- a/url.c
+++ b/url.c
@@ -626,7 +626,7 @@ url_t *url_set(char *str)
   }
 
   if((sl = slist_getentry(url->query, "quiet"))) {
-    url->quiet = strtoul(sl->value, NULL, 0);
+    url->quiet = sl->value ? strtoul(sl->value, NULL, 0) : 1;
   }
 
   url->is.mountable = url_is_mountable(url->scheme);


### PR DESCRIPTION
## Task

Port  https://github.com/openSUSE/linuxrc/pull/324 and  https://github.com/openSUSE/linuxrc/pull/325 to SLE15-SP5.

## Original tasks

1.  https://bugzilla.suse.com/show_bug.cgi?id=1213683
  When choosing a service type other than the default `install.suse`, linuxrc creates a malformed SLP packet with an incorrect 'Service Type Length' field.
2.  https://bugzilla.suse.com/show_bug.cgi?id=1213531
   Add `auto` slp URL parameter to skip interactive dialog presenting a list of matching SLP entries and automatically use the first entry.