### PR TITLE
write /etc/locale.conf and /etc/vconsole.conf (bsc#1218621)

### DIFF
--- a/file.c
+++ b/file.c
@@ -2028,10 +2028,6 @@ void file_write_install_inf(char *dir)
 
   set_write_info(f);
 
-  if(config.keymap_set || config.manual) {
-    file_write_str(f, key_keytable, config.keymap);
-  }
-
   file_write_str(f, key_console, config.serial);
 
   // don't leave anything mounted unless we're low in memory and run yast

--- a/global.h
+++ b/global.h
@@ -491,6 +491,7 @@ typedef struct {
   enum langid_t language;	/**< currently selected language */
   char *keymap;			/**< current keymap */
   unsigned keymap_set:1;	/**< explicitly set via 'keytable' option */
+  unsigned keymap_applied:1;	/**< config.keymap has been applied via loadkeys command */
   unsigned sourcetype:1;	/**< 0: directory, 1: file */
   char *new_root;		/**< root device to boot */
   char *rootimage;		/**< "boot/<arch>/root" */

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -413,6 +413,8 @@ void lxrc_change_root()
     /* change hostname from 'install' to 'rescue' unless we've had something better */
     if(!config.net.realhostname) util_set_hostname("rescue");
 
+    file_write_install_inf("");
+
     lxrc_run_console("/mounts/initrd/scripts/prepare_rescue");
 
     LXRC_WAIT

--- a/linuxrc.c
+++ b/linuxrc.c
@@ -955,7 +955,7 @@ void lxrc_init()
     if (config.linemode)
       putchar('\n');
     printf(
-      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2023 SUSE LLC %s <<<\n",
+      "\n>>> %s installation program v" LXRC_FULL_VERSION " (c) 1996-2024 SUSE LLC %s <<<\n",
       config.product,
       config.platform_name
     );

--- a/settings.h
+++ b/settings.h
@@ -30,7 +30,7 @@ extern void set_choose_keytable (int);
 extern void set_activate_language(enum langid_t lang_id);
 extern void set_activate_keymap (char *keymap);
 extern void set_choose_language (void);
-extern void set_write_info      (FILE *f);
+extern void set_write_info      (FILE *install_inf);
 language_t *current_language    (void);
 extern void set_expert_menu     (void);
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1218621

`/etc/locale.conf` and `/etc/vconsole.conf` are not created but systemd expects them in the rescue system.

## Solution

Always create these files (also in the installation system).

As a side effect, the rescue system now also has `/etc/install.inf`.