### PR TITLE
fix width of network device dialog (bsc#1221360)

### DIFF
--- a/dialog.c
+++ b/dialog.c
@@ -1649,6 +1649,8 @@ dia_item_t dia_menu2(char *title, int width, int (*func)(dia_item_t), dia_item_t
 
 /*
  * returns selected item (1 based), or 0 (ESC pressed)
+ *
+ * Use width = 0 to have width automatically calculated to fit the longest item.
  */
 int dia_list(char *title, int width, int (*func)(int), char **items, int default_item, dia_align_t align)
 {
@@ -1663,6 +1665,17 @@ int dia_list(char *title, int width, int (*func)(int), char **items, int default
   if(!config.win) util_disp_init();
 
   item_list = calloc(item_cnt, sizeof *item_list);
+
+  if(width == 0) {
+    for(i = 0, it = items; *it; it++, i++) {
+      int w = strlen(*it);
+      if(w > width) width = w;
+    }
+
+    width += 1;
+    if(width < 20) width = 20;
+    if(width > max_x_ig - 6) width = max_x_ig - 6;
+  }
 
   util_create_items(item_list, item_cnt, width);
 

--- a/net.c
+++ b/net.c
@@ -763,7 +763,7 @@ int net_choose_device()
     choice = 1;
   }
   else {
-    choice = dia_list("Choose the network device.", 72, NULL, items, last_item, align_left);
+    choice = dia_list("Choose the network device.", 0, NULL, items, last_item, align_left);
     if(choice) last_item = choice;
   }
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221360

Items in network device list are cut even though there's space available on screen.

## Solution

Select width of network device list automatically to match item size.