### PR TITLE
add 'repo' URL scheme to linuxrc (jsc#SLE-22578, jsc#SLE-24584, bsc#1223326) 

### DIFF
--- a/auto2.c
+++ b/auto2.c
@@ -888,7 +888,7 @@ void auto2_read_repo_files(url_t *url)
 
   if(config.url.autoyast) {
     if(
-      config.url.autoyast->scheme == inst_rel &&
+      (config.url.autoyast->scheme == inst_rel || config.url.autoyast->scheme == inst_repo) &&
       config.autoyast_parse
     ) {
       log_show_maybe(!config.url.autoyast->quiet, "AutoYaST file in repo: %s\n", url_print(config.url.autoyast, 5));
@@ -908,9 +908,12 @@ void auto2_read_repo_files(url_t *url)
     if(util_check_exist("/tmp/autoinst.xml")) rename("/tmp/autoinst.xml", "/autoinst.xml");
 
     if(util_check_exist("/autoinst.xml")) {
-      log_info("setting AutoYaST option to file:/autoinst.xml\n");
-      url_free(config.url.autoyast);
-      config.url.autoyast = url_set("file:/autoinst.xml");
+      // with repo scheme, pass the the original URL to yast
+      if(config.url.autoyast->scheme != inst_repo) {
+        log_info("setting AutoYaST option to file:/autoinst.xml\n");
+        url_free(config.url.autoyast);
+        config.url.autoyast = url_set("file:/autoinst.xml");
+      }
       // parse for embedded linuxrc options in <info_file> element
       log_info("parsing AutoYaST file\n");
       file_read_info_file("file:/autoinst.xml", kf_cfg);
@@ -1095,7 +1098,7 @@ int auto2_add_extension(char *extension)
     err = 1;
   }
 
-  if(config.url.instsys->scheme == inst_rel && !config.url.install) {
+  if((config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo)  && !config.url.install) {
     log_info("no repo\n");
     err = 2;
   }
@@ -1107,7 +1110,7 @@ int auto2_add_extension(char *extension)
 
   strprintf(&config.url.instsys->path, "%s/%s", s, extension);
 
-  if(config.url.instsys->scheme == inst_rel) {
+  if(config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo) {
     err = url_find_repo(config.url.install, config.mountpoint.instdata);
   }
 
@@ -1227,7 +1230,7 @@ void auto2_read_autoyast(url_t *url)
   if(!url) return;
 
   // rel url is taken care of in auto2_read_repo_files()
-  if(url->scheme == inst_rel) return;
+  if(url->scheme == inst_rel || url->scheme == inst_repo) return;
 
   /*
    * If the AutoYaST url is a directory we have to verify its existence

--- a/auto2.c
+++ b/auto2.c
@@ -888,7 +888,7 @@ void auto2_read_repo_files(url_t *url)
 
   if(config.url.autoyast) {
     if(
-      (config.url.autoyast->scheme == inst_rel || config.url.autoyast->scheme == inst_repo) &&
+      config.url.autoyast->is.relative &&
       config.autoyast_parse
     ) {
       log_show_maybe(!config.url.autoyast->quiet, "AutoYaST file in repo: %s\n", url_print(config.url.autoyast, 5));
@@ -1098,7 +1098,7 @@ int auto2_add_extension(char *extension)
     err = 1;
   }
 
-  if((config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo)  && !config.url.install) {
+  if(config.url.instsys->is.relative && !config.url.install) {
     log_info("no repo\n");
     err = 2;
   }
@@ -1110,7 +1110,7 @@ int auto2_add_extension(char *extension)
 
   strprintf(&config.url.instsys->path, "%s/%s", s, extension);
 
-  if(config.url.instsys->scheme == inst_rel || config.url.instsys->scheme == inst_repo) {
+  if(config.url.instsys->is.relative) {
     err = url_find_repo(config.url.install, config.mountpoint.instdata);
   }
 
@@ -1230,7 +1230,7 @@ void auto2_read_autoyast(url_t *url)
   if(!url) return;
 
   // rel url is taken care of in auto2_read_repo_files()
-  if(url->scheme == inst_rel || url->scheme == inst_repo) return;
+  if(url->is.relative) return;
 
   /*
    * If the AutoYaST url is a directory we have to verify its existence

--- a/global.h
+++ b/global.h
@@ -185,7 +185,7 @@ typedef enum {
   inst_none = 0, inst_file, inst_nfs, inst_ftp, inst_smb,
   inst_http, inst_https, inst_tftp, inst_cdrom, inst_floppy, inst_hd,
   inst_dvd, inst_cdwithnet, inst_net, inst_slp, inst_exec,
-  inst_rel, inst_disk, inst_usb, inst_label,
+  inst_rel, inst_disk, inst_usb, inst_label, inst_repo,
   inst_extern ///< must be last
 } instmode_t;
 

--- a/global.h
+++ b/global.h
@@ -291,6 +291,7 @@ typedef struct {
     unsigned wlan:1;		/**< wlan interface */
     unsigned blockdev:1;	/**< needs block device */
     unsigned nodevneeded:1;	/**< does not need any device */
+    unsigned relative:1;	/**< url is relative (to some other url) */
   } is;
   struct {
     char *device;

--- a/url.c
+++ b/url.c
@@ -662,6 +662,8 @@ url_t *url_set(char *str)
     }
   }
 
+  if(url->scheme == inst_rel || url->scheme == inst_repo) url->is.relative = 1;
+
   url_replace_vars_with_backup(&url->server, &url->orig.server);
   url_replace_vars_with_backup(&url->share, &url->orig.share);
   url_replace_vars_with_backup(&url->path, &url->orig.path);
@@ -716,9 +718,9 @@ void url_log(url_t *url)
   }
 
   log_debug(
-    "  network = %u, blockdev = %u, mountable = %u, file = %u, dir = %u, all = %u, quiet = %u\n",
+    "  network = %u, blockdev = %u, mountable = %u, file = %u, dir = %u, relative = %u, all = %u, quiet = %u\n",
     url->is.network, url->is.blockdev, url->is.mountable, url->is.file, url->is.dir,
-    url->search_all, url->quiet
+    url->is.relative, url->search_all, url->quiet
   );
 
   if(url->instsys) log_debug("  instsys = %s\n", url->instsys);
@@ -2672,7 +2674,7 @@ static int test_is_repo(url_t *url)
   }
 
   if(
-    (config.url.instsys->scheme != inst_rel && config.url.instsys->scheme != inst_repo) ||
+    !config.url.instsys->is.relative ||
     config.kexec == 1
   ) return 1;
 
@@ -2873,8 +2875,7 @@ int url_find_instsys(url_t *url, char *dir)
   if(
     !url ||
     !url->scheme ||
-    url->scheme == inst_rel ||
-    url->scheme == inst_repo ||
+    url->is.relative ||
     !url->path
   ) return 1;
 

--- a/url.c
+++ b/url.c
@@ -1091,18 +1091,18 @@ char *url_print_zypp(url_t *url)
   if(path) {
     strprintf(&buf, "%s/%s%s",
       buf,
-      url->scheme == inst_ftp && *path == '/' ? "%2F" : "",
+      scheme == inst_ftp && *path == '/' ? "%2F" : "",
       *path == '/' ? path + 1 : path
     );
   }
 
-  if(url->scheme == inst_hd) {
+  if(scheme == inst_hd) {
     if((s = url->used.device) || (s = url->device)) {
       strprintf(&buf, "%s%cdevice=%s", buf, q++ ? '&' : '?', long_dev(s));
     }
   }
 
-  if(url->scheme == inst_cdrom) {
+  if(scheme == inst_cdrom) {
     if((s = url->used.device) || (s = url->device)) {
       strprintf(&buf, "%s%cdevices=%s", buf, q++ ? '&' : '?', long_dev(s));
     }
@@ -1111,10 +1111,10 @@ char *url_print_zypp(url_t *url)
   if(
     config.url.proxy &&
     config.url.proxy->server && (
-      url->scheme == inst_http ||
-      url->scheme == inst_https ||
-      url->scheme == inst_ftp ||
-      url->scheme == inst_tftp
+      scheme == inst_http ||
+      scheme == inst_https ||
+      scheme == inst_ftp ||
+      scheme == inst_tftp
     )
   ) {
     strprintf(&buf, "%s%cproxy=%s", buf, q++ ? '&' : '?', config.url.proxy->server);

--- a/url.c
+++ b/url.c
@@ -122,6 +122,7 @@ static struct {
   { "disk",      inst_disk          },
   { "usb",       inst_usb           },
   { "label",     inst_label         },
+  { "repo",      inst_repo          },
   /* add new inst modes _here_! (before "extern") */
   { "extern",    inst_extern        },
   /* the following are just aliases */
@@ -2670,7 +2671,10 @@ static int test_is_repo(url_t *url)
     str_copy(&buf2, NULL);
   }
 
-  if(config.url.instsys->scheme != inst_rel || config.kexec == 1) return 1;
+  if(
+    (config.url.instsys->scheme != inst_rel && config.url.instsys->scheme != inst_repo) ||
+    config.kexec == 1
+  ) return 1;
 
   if(!config.keepinstsysconfig) {
     instsys_config = url_instsys_config(config.url.instsys->path);
@@ -2870,6 +2874,7 @@ int url_find_instsys(url_t *url, char *dir)
     !url ||
     !url->scheme ||
     url->scheme == inst_rel ||
+    url->scheme == inst_repo ||
     !url->path
   ) return 1;
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1223326

Port https://github.com/openSUSE/linuxrc/pull/299 to SLE15-SP5.

## Original task

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

yast has a `relurl` URL scheme that has different interpretations as to *what* it is relative to depending on the context a URL is used in.

The task is to have something that is always relative to the installation medium (with the repository).

## Solution

The new `repo` scheme is basically the same as `rel` - that is, relative to the installation repository with the difference that it is never  rewritten to point to the actual location but passed to yast in unmodified form.

## Note

There is already a `rel` scheme in linuxrc and a `relurl` scheme in yast. The task is to remove the existing ambiguity in the `relurl` interpretation. As not to break existing profiles which would just add to the confusion, a completely new URL scheme is introduced.

## Bonus

There was a bug preventing the device name link passed to the Zypp scheme format when using `disk` and `hd` URL schemes.

## See also

- https://github.com/yast/yast-installation/pull/1063
- https://github.com/yast/yast-yast2/pull/1276
- https://github.com/yast/yast-autoinstallation/pull/852