### PR TITLE
switch to tty1 if framebuffer device becomes available - now on all architectures (bsc#1225539)

### DIFF
--- a/linuxrc.c
+++ b/linuxrc.c
@@ -860,8 +860,8 @@ void lxrc_init()
   config.autoyast_parse = 1;	/* analyse autoyast option and read autoyast file */
 #if defined(__s390x__)
   config.device_auto_config = 2;	/* ask before doing s390 device auto config */
-  config.switch_to_fb = 1;
 #endif
+  config.switch_to_fb = 1;
 
   // defaults for self-update feature
   config.self_update_url = NULL;


### PR DESCRIPTION
## Task

Set the default value of boot option `switch_to_fb` to 1.

This used to be limited to S390X in the SLE15 code stream - mainly to gather some experience in Tumbleweed.

## See also

- https://github.com/openSUSE/linuxrc/pull/281