### PR TITLE
fix incorrect check of open() return value (bsc#1257832)

### DIFF
--- a/url.c
+++ b/url.c
@@ -718,13 +718,18 @@ void url_log(url_t *url)
   }
 
   log_debug(
-    "  network = %u, blockdev = %u, mountable = %u, file = %u, dir = %u, relative = %u, all = %u, quiet = %u\n",
+    "  network = %u, blockdev = %u, mountable = %u, file = %u, dir = %u, relative = %u, all = %u, download = %u, quiet = %u\n",
     url->is.network, url->is.blockdev, url->is.mountable, url->is.file, url->is.dir,
-    url->is.relative, url->search_all, url->quiet
+    url->is.relative, url->search_all, url->download, url->quiet
   );
 
   if(url->instsys) log_debug("  instsys = %s\n", url->instsys);
   if(url->orig.instsys) log_debug("  instsys (orig) = %s\n", url->orig.instsys);
+
+  if(url->used.device) log_debug("  used.device = %s\n", url->used.device);
+  if(url->used.hwaddr) log_debug("  used.hwaddr = %s\n", url->used.hwaddr);
+  if(url->used.model) log_debug("  used.model = %s\n", url->used.model);
+  if(url->used.unique_id) log_debug("  used.unique_id = %s\n", url->used.unique_id);
 
   if(url->query) {
     log_debug("  query:\n");

--- a/util.c
+++ b/util.c
@@ -133,7 +133,7 @@ void util_redirect_kmsg()
 
   if(loglevel) klogctl(8, NULL, loglevel);
 
-  if(!config.serial && (fd = open(config.console, O_RDONLY))) {
+  if(!config.serial && (fd = open(config.console, O_RDONLY)) != -1) {
     ioctl(fd, TIOCLINUX, &newvt);
     close(fd);
     /* 'create' console 4 */
@@ -343,7 +343,7 @@ int util_fileinfo(char *file_name, int *size, int *compressed)
   if(size) *size = 0;
   if(compressed) *compressed = 0;
 
-  if(!(fd = open(file_name, O_RDONLY | O_LARGEFILE))) return -1;
+  if((fd = open(file_name, O_RDONLY | O_LARGEFILE)) == -1) return -1;
 
   if(read(fd, buf, 2) != 2) {
     close(fd);


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1257832

Due to incorrect interpretation of the return value of open() the code could under some circumstances assume the installation media is not readable.

## Solution

Verify all code locations using open().